### PR TITLE
feat: add comment support to the lexer

### DIFF
--- a/compiler/zrc_parser/src/lexer.rs
+++ b/compiler/zrc_parser/src/lexer.rs
@@ -39,7 +39,7 @@ fn handle_block_comment_start(lex: &mut Lexer<'_, Tok>) -> logos::FilterResult<(
             ('/', Some(&'*')) => {
                 chars.next();
                 lex.bump(1);
-                depth += 1
+                depth += 1;
             }
             // And the inverse for */...
             ('*', Some(&'/')) => {

--- a/compiler/zrc_parser/src/lexer.rs
+++ b/compiler/zrc_parser/src/lexer.rs
@@ -9,10 +9,65 @@ pub enum LexicalError {
     // TODO: Better rename IDK to something a little more descriptive
     IDK((usize, char), String),
     UnterminatedStringLiteral(usize),
+    /// A block comment ran to the end of the file. Remind the user that block comments nest.
+    UnterminatedBlockComment,
 }
 
 fn string_slice(lex: &mut Lexer<'_, Tok>) -> String {
     lex.slice().to_string()
+}
+
+/// Zirco uses nested block comments -- a regular expression can't match this without recursion,
+/// so our approach is to use a custom callback which takes the lexer and basically consumes
+/// characters in our input until we reach the end of the comment.
+/// See also: https://github.com/maciejhirsz/logos/issues/307
+/// See also: https://github.com/zirco-lang/zrc/pull/14
+fn handle_block_comment_start(lex: &mut Lexer<'_, Tok>) -> logos::FilterResult<(), LexicalError> {
+    let mut depth = 1;
+    // This contains all of the remaining tokens in our input except for the opening to this comment
+    // -- that's already been consumed.
+    let mut chars = lex.remainder().chars().peekable();
+
+    // We iterate over all of the remaining characters in the input...
+    while let Some(char) = chars.next() {
+        // ...tell the Lexer this token spans into this character...
+        lex.bump(1);
+
+        // and perform some action for each sequence of 2 characters:
+        match (char, chars.peek()) {
+            // If it's "/*", we're starting a new comment, consume the '*' and increase our depth...
+            ('/', Some(&'*')) => {
+                chars.next();
+                lex.bump(1);
+                depth += 1
+            }
+            // And the inverse for */...
+            ('*', Some(&'/')) => {
+                chars.next();
+                lex.bump(1);
+                depth -= 1;
+            }
+            // Any other sequence can be ignored.
+            _ => {}
+        }
+
+        // If we've exited our last comment, we're all done!
+        if depth == 0 {
+            break;
+        }
+    }
+
+    if depth == 0 {
+        // We've reached the end of this block comment - because we attach the handle_block_comment_start
+        // callback to basically any token variant (to keep the Tok enum clean of useless variants),
+        // we should simply skip this token. This will skip from the beginning of our Span to the end
+        // that was given through all of the calls to lex.bump().
+        logos::FilterResult::Skip
+    } else {
+        // This means we've reached the end of our input still in a comment.
+        // We can throw an error here.
+        logos::FilterResult::Error(LexicalError::UnterminatedBlockComment)
+    }
 }
 
 #[derive(Logos, Debug, Clone, PartialEq)]
@@ -20,9 +75,14 @@ fn string_slice(lex: &mut Lexer<'_, Tok>) -> String {
     error = LexicalError,
     skip r"[ \t\r\n\f]+",         // whitespace
     skip r"//[^\r\n]*(\r\n|\n)?", // single-line comments
-    skip r"/\*([^*]|\*[^/])+\*/"  // multi-line comments (no nesting) TODO: support nesting
+    // multi-line comments are handled by a callback: see handle_block_comment_start.
 )]
 pub enum Tok {
+    // Handle nested block comments -- this does not need its own token type and can be attached
+    // to whatever token is directly below this. The handle_block_comment_start will either Skip the
+    // matched characters or throw an error. It will never return a token.
+    // Read the doc comment above handle_block_comment_start for more information.
+    #[token("/*", handle_block_comment_start)]
     // === ARITHMETIC OPERATORS ===
     /// The token `+`
     #[token("+")]
@@ -338,24 +398,30 @@ mod tests {
     }
 
     /// Nested comments
-    /// This test is to test for a regression reguarding the current behavior
-    /// of nested comments. Currently, comment nesting is not supported -- in the future,
-    /// we'd like this to be a feature.
     #[test]
     fn comments_3() {
-        let lexer = ZircoLexer::new("a/* /* */b"); // should lex OK
+        let lexer = ZircoLexer::new("a/* /* */ */b"); // should lex OK
         let tokens: Vec<_> = lexer.collect();
         assert_eq!(
             tokens,
             vec![
                 Ok((0, Tok::Identifier("a".to_string()), 1)),
-                Ok((9, Tok::Identifier("b".to_string()), 10))
+                Ok((12, Tok::Identifier("b".to_string()), 13))
             ]
         );
-        // Future expected case:
-        // a/* /*  */ *b/ with this failing
     }
 
-    // TODO: What does the error look like for an unclosed comment? It might be
-    // an ugly IDK() error and I don't like that.
+    /// Unclosed nested comment
+    #[test]
+    fn comments_4() {
+        let lexer = ZircoLexer::new("a /* /*");
+        let tokens: Vec<_> = lexer.collect();
+        assert_eq!(
+            tokens,
+            vec![
+                Ok((0, Tok::Identifier("a".to_string()), 1)),
+                Err(LexicalError::UnterminatedBlockComment)
+            ]
+        )
+    }
 }


### PR DESCRIPTION
- [x] Requires PR #13 to be merged first (there will be conflicts due to logos skip behavior)
- [x] Further discussion on nested comments -- should we use them or not? This PR currently does *not* support nested comments.
  - My verdict: YES - they are helpful.
  - @ei-pi's verdict: YES
- [x] What does the error for an unclosed comment look like, and can we change it to be a little cleaner? Maybe this means no more logos after all.
  - The addition of nested comments in a66e95a gives us a new clean error message.