### PR TITLE
add basic HIR

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -733,6 +733,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "zrc_hir"
+version = "0.1.0"
+dependencies = [
+ "zrc_parser",
+]
+
+[[package]]
 name = "zrc_parser"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,4 +2,5 @@
 members = [
     "compiler/zrc",
     "compiler/zrc_parser",
+    "compiler/zrc_hir",
 ]

--- a/compiler/zrc_hir/Cargo.toml
+++ b/compiler/zrc_hir/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "zrc_hir"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+zrc_parser = { version = "0.1.0", path = "../zrc_parser" }

--- a/compiler/zrc_hir/src/hir.rs
+++ b/compiler/zrc_hir/src/hir.rs
@@ -1,0 +1,5 @@
+#![allow(ambiguous_associated_items)]
+
+pub mod expr;
+pub mod stmt;
+pub mod ty;

--- a/compiler/zrc_hir/src/hir/expr.rs
+++ b/compiler/zrc_hir/src/hir/expr.rs
@@ -1,0 +1,126 @@
+use std::fmt::Display;
+
+/// The HIR version of the [zrc_parser::ast::expr::Expr] type.
+/// All that is different here is all [zrc_parser::ast::expr::Expr::Error] variants are invalid.
+/// Generate with the [super::super::lower_ast::lower_expr] function.
+#[derive(PartialEq, Debug, Clone)]
+pub enum Expr {
+    Comma(Box<Expr>, Box<Expr>),
+
+    Assignment(Box<Expr>, Box<Expr>),
+    AdditionAssignment(Box<Expr>, Box<Expr>),
+    SubtractionAssignment(Box<Expr>, Box<Expr>),
+    MultiplicationAssignment(Box<Expr>, Box<Expr>),
+    DivisionAssignment(Box<Expr>, Box<Expr>),
+    ModuloAssignment(Box<Expr>, Box<Expr>),
+    BitwiseAndAssignment(Box<Expr>, Box<Expr>),
+    BitwiseOrAssignment(Box<Expr>, Box<Expr>),
+    BitwiseXorAssignment(Box<Expr>, Box<Expr>),
+    BitwiseLeftShiftAssignment(Box<Expr>, Box<Expr>),
+    BitwiseRightShiftAssignment(Box<Expr>, Box<Expr>),
+
+    UnaryNot(Box<Expr>),
+    UnaryBitwiseNot(Box<Expr>),
+    UnaryMinus(Box<Expr>),
+    UnaryAddressOf(Box<Expr>),
+    UnaryDereference(Box<Expr>),
+
+    Index(Box<Expr>, Box<Expr>),
+    Dot(Box<Expr>, String),
+    Arrow(Box<Expr>, String),
+    Call(Box<Expr>, Vec<Expr>),
+
+    Ternary(Box<Expr>, Box<Expr>, Box<Expr>),
+
+    LogicalAnd(Box<Expr>, Box<Expr>),
+    LogicalOr(Box<Expr>, Box<Expr>),
+
+    Equals(Box<Expr>, Box<Expr>),
+    NotEquals(Box<Expr>, Box<Expr>),
+
+    BitwiseAnd(Box<Expr>, Box<Expr>),
+    BitwiseOr(Box<Expr>, Box<Expr>),
+    BitwiseXor(Box<Expr>, Box<Expr>),
+
+    GreaterThan(Box<Expr>, Box<Expr>),
+    GreaterThanOrEqualTo(Box<Expr>, Box<Expr>),
+    LessThan(Box<Expr>, Box<Expr>),
+    LessThanOrEqualTo(Box<Expr>, Box<Expr>),
+
+    BitwiseRightShift(Box<Expr>, Box<Expr>),
+    BitwiseLeftShift(Box<Expr>, Box<Expr>),
+
+    Addition(Box<Expr>, Box<Expr>),
+    Subtraction(Box<Expr>, Box<Expr>),
+
+    Multiplication(Box<Expr>, Box<Expr>),
+    Division(Box<Expr>, Box<Expr>),
+    Modulo(Box<Expr>, Box<Expr>),
+
+    NumberLiteral(String),
+    StringLiteral(String),
+    Identifier(String),
+    BooleanLiteral(bool),
+}
+
+impl Display for Expr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "(")?;
+        match self {
+            Expr::NumberLiteral(n) => write!(f, "{}", n),
+            Expr::StringLiteral(s) => write!(f, "{}", s),
+            Expr::Identifier(i) => write!(f, "{}", i),
+            Expr::BooleanLiteral(b) => write!(f, "{}", b),
+            Expr::Assignment(l, r) => write!(f, "{} = {}", l, r),
+            Expr::Addition(l, r) => write!(f, "{} + {}", l, r),
+            Expr::Subtraction(l, r) => write!(f, "{} - {}", l, r),
+            Expr::Multiplication(l, r) => write!(f, "{} * {}", l, r),
+            Expr::Division(l, r) => write!(f, "{} / {}", l, r),
+            Expr::Modulo(l, r) => write!(f, "{} % {}", l, r),
+            Expr::BitwiseAnd(l, r) => write!(f, "{} & {}", l, r),
+            Expr::BitwiseOr(l, r) => write!(f, "{} | {}", l, r),
+            Expr::BitwiseXor(l, r) => write!(f, "{} ^ {}", l, r),
+            Expr::BitwiseLeftShift(l, r) => write!(f, "{} << {}", l, r),
+            Expr::BitwiseRightShift(l, r) => write!(f, "{} >> {}", l, r),
+            Expr::GreaterThan(l, r) => write!(f, "{} > {}", l, r),
+            Expr::GreaterThanOrEqualTo(l, r) => write!(f, "{} >= {}", l, r),
+            Expr::LessThan(l, r) => write!(f, "{} < {}", l, r),
+            Expr::LessThanOrEqualTo(l, r) => write!(f, "{} <= {}", l, r),
+            Expr::Equals(l, r) => write!(f, "{} == {}", l, r),
+            Expr::NotEquals(l, r) => write!(f, "{} != {}", l, r),
+            Expr::LogicalAnd(l, r) => write!(f, "{} && {}", l, r),
+            Expr::LogicalOr(l, r) => write!(f, "{} || {}", l, r),
+            Expr::Comma(l, r) => write!(f, "{}, {}", l, r),
+            Expr::AdditionAssignment(l, r) => write!(f, "{} += {}", l, r),
+            Expr::SubtractionAssignment(l, r) => write!(f, "{} -= {}", l, r),
+            Expr::MultiplicationAssignment(l, r) => write!(f, "{} *= {}", l, r),
+            Expr::DivisionAssignment(l, r) => write!(f, "{} /= {}", l, r),
+            Expr::ModuloAssignment(l, r) => write!(f, "{} %= {}", l, r),
+            Expr::BitwiseAndAssignment(l, r) => write!(f, "{} &= {}", l, r),
+            Expr::BitwiseOrAssignment(l, r) => write!(f, "{} |= {}", l, r),
+            Expr::BitwiseXorAssignment(l, r) => write!(f, "{} ^= {}", l, r),
+            Expr::BitwiseLeftShiftAssignment(l, r) => write!(f, "{} <<= {}", l, r),
+            Expr::BitwiseRightShiftAssignment(l, r) => write!(f, "{} >>= {}", l, r),
+            Expr::UnaryNot(e) => write!(f, "!{}", e),
+            Expr::UnaryBitwiseNot(e) => write!(f, "~{}", e),
+            Expr::UnaryMinus(e) => write!(f, "-{}", e),
+            Expr::UnaryAddressOf(e) => write!(f, "&{}", e),
+            Expr::UnaryDereference(e) => write!(f, "*{}", e),
+            Expr::Arrow(l, r) => write!(f, "{}->{}", l, r),
+            Expr::Ternary(l, m, r) => write!(f, "{} ? {} : {}", l, m, r),
+            Expr::Index(a, b) => write!(f, "{}[{}]", a, b),
+            Expr::Dot(a, b) => write!(f, "{}.{}", a, b),
+            Expr::Call(a, b) => write!(
+                f,
+                "{}({})",
+                a,
+                b.iter()
+                    .map(|x| x.to_string())
+                    .collect::<Vec<String>>()
+                    .join(", ")
+            ),
+        }?;
+        write!(f, ")")?;
+        Ok(())
+    }
+}

--- a/compiler/zrc_hir/src/hir/stmt.rs
+++ b/compiler/zrc_hir/src/hir/stmt.rs
@@ -1,0 +1,187 @@
+//! The HIR version of the [zrc_parser::ast::stmt] module.
+//!
+//! The HIR performs a few desugaring steps. First of all, all statements on their own are automatically placed within blocks.
+//! Additionally, for loops are desugared to while loops, and while loops are all desugared to infinite loops with a break statement.
+//!
+//! Generate with the [super::super::lower_ast::lower_block] function.
+
+use super::expr::Expr;
+use super::ty::Type;
+use std::fmt::Display;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct LetDeclaration {
+    pub name: String,
+    pub ty: Option<Type>,
+    pub value: Option<Expr>,
+}
+
+impl Display for LetDeclaration {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &self.ty {
+            None => match &self.value {
+                None => write!(f, "{}", self.name),
+                Some(v) => write!(f, "{} = {}", self.name, v),
+            },
+            Some(t) => match &self.value {
+                None => write!(f, "{}: {}", self.name, t),
+                Some(v) => write!(f, "{}: {} = {}", self.name, t, v),
+            },
+        }
+    }
+}
+
+#[derive(PartialEq, Debug, Clone)]
+pub enum Stmt {
+    IfStmt {
+        cond: Expr,
+        then: Vec<Stmt>,
+        then_else: Option<Vec<Stmt>>,
+    },
+    InfiniteLoop(Vec<Stmt>),
+    BlockStmt(Vec<Stmt>),
+    ExprStmt(Expr),
+    EmptyStmt,
+    ContinueStmt,
+    BreakStmt,
+    ReturnStmt(Option<Expr>),
+    Declaration(Declaration),
+}
+
+/// Any declaration valid to be present at the top level of a file
+#[derive(PartialEq, Debug, Clone)]
+pub enum Declaration {
+    DeclarationList(Vec<LetDeclaration>),
+    FunctionDefinition {
+        name: String,
+        parameters: Vec<ArgumentDeclaration>,
+        return_type: Option<Type>,
+        body: Vec<Stmt>,
+    },
+}
+
+impl Display for Declaration {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Declaration::DeclarationList(l) => {
+                write!(
+                    f,
+                    "let {};",
+                    l.iter()
+                        .map(|x| x.to_string())
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                )
+            }
+            Declaration::FunctionDefinition {
+                name,
+                parameters,
+                return_type: Some(r),
+                body,
+            } => write!(
+                f,
+                "fn {name}({}) -> {r} {{ {} }}",
+                parameters
+                    .iter()
+                    .map(|x| x.to_string())
+                    .collect::<Vec<String>>()
+                    .join(", "),
+                body.iter()
+                    .map(|x| x.to_string())
+                    .collect::<Vec<String>>()
+                    .join(" ")
+            ),
+            Declaration::FunctionDefinition {
+                name,
+                parameters,
+                return_type: None,
+                body,
+            } => write!(
+                f,
+                "fn {name}({}) {{ {} }}",
+                parameters
+                    .iter()
+                    .map(|x| x.to_string())
+                    .collect::<Vec<String>>()
+                    .join(", "),
+                body.iter()
+                    .map(|x| x.to_string())
+                    .collect::<Vec<String>>()
+                    .join(" ")
+            ),
+        }
+    }
+}
+
+impl Display for Stmt {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Stmt::IfStmt {
+                cond,
+                then,
+                then_else: None,
+            } => write!(
+                f,
+                "if ({cond}) {{ {} }}",
+                then.iter()
+                    .map(|x| x.to_string())
+                    .collect::<Vec<_>>()
+                    .join(" ")
+            ),
+            Stmt::IfStmt {
+                cond,
+                then,
+                then_else: Some(then_else),
+            } => write!(
+                f,
+                "if ({cond}) {{ {} }} else {{ {} }}",
+                then.iter()
+                    .map(|x| x.to_string())
+                    .collect::<Vec<_>>()
+                    .join(" "),
+                then_else
+                    .iter()
+                    .map(|x| x.to_string())
+                    .collect::<Vec<_>>()
+                    .join(" ")
+            ),
+            Stmt::InfiniteLoop(body) => write!(
+                f,
+                "while (true) {{ {} }}",
+                body.iter()
+                    .map(|x| x.to_string())
+                    .collect::<Vec<_>>()
+                    .join(" ")
+            ),
+            Stmt::BlockStmt(s) => {
+                write!(f, "{{")?;
+                for stmt in s {
+                    write!(f, "{stmt}")?;
+                }
+                write!(f, "}}")
+            }
+            Stmt::ExprStmt(e) => write!(f, "{e};"),
+            Stmt::EmptyStmt => write!(f, ";"),
+            Stmt::ContinueStmt => write!(f, "continue;"),
+            Stmt::BreakStmt => write!(f, "break;"),
+            Stmt::ReturnStmt(Some(e)) => write!(f, "return {e};",),
+            Stmt::ReturnStmt(None) => write!(f, "return;"),
+            Stmt::Declaration(d) => write!(f, "{}", d),
+        }
+    }
+}
+
+#[derive(PartialEq, Debug, Clone)]
+pub struct ArgumentDeclaration {
+    pub name: String,
+    pub ty: Option<Type>,
+}
+
+impl Display for ArgumentDeclaration {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &self.ty {
+            None => write!(f, "{}", self.name),
+            Some(t) => write!(f, "{}: {}", self.name, t),
+        }
+    }
+}

--- a/compiler/zrc_hir/src/hir/ty.rs
+++ b/compiler/zrc_hir/src/hir/ty.rs
@@ -1,0 +1,14 @@
+use std::fmt::Display;
+
+#[derive(PartialEq, Debug, Clone)]
+pub enum Type {
+    Identifier(String),
+}
+
+impl Display for Type {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Type::Identifier(i) => write!(f, "{}", i),
+        }
+    }
+}

--- a/compiler/zrc_hir/src/lib.rs
+++ b/compiler/zrc_hir/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod hir;
+pub mod lower_ast;

--- a/compiler/zrc_hir/src/lib.rs
+++ b/compiler/zrc_hir/src/lib.rs
@@ -1,2 +1,11 @@
+#![warn(
+    clippy::cargo,
+    clippy::nursery,
+    clippy::pedantic,
+    clippy::missing_docs_in_private_items,
+    missing_docs
+)]
+#![allow(clippy::multiple_crate_versions)]
+
 pub mod hir;
 pub mod lower_ast;

--- a/compiler/zrc_hir/src/lower_ast.rs
+++ b/compiler/zrc_hir/src/lower_ast.rs
@@ -1,0 +1,377 @@
+pub fn lower_expr(expr: zrc_parser::ast::expr::Expr) -> Result<super::hir::expr::Expr, String> {
+    use super::hir::expr::Expr as HirExpr;
+    use zrc_parser::ast::expr::Expr as AstExpr;
+    match expr {
+        AstExpr::Error => Err("Parse error encountered. Cannot lower to HIR.".to_string()), // TODO: Allow this to lower, that way we can try to type check even with errors present
+
+        AstExpr::Comma(a, b) => Ok(HirExpr::Comma(
+            Box::new(lower_expr(*a)?),
+            Box::new(lower_expr(*b)?),
+        )),
+        AstExpr::Assignment(a, b) => Ok(HirExpr::Assignment(
+            Box::new(lower_expr(*a)?),
+            Box::new(lower_expr(*b)?),
+        )),
+        AstExpr::AdditionAssignment(a, b) => Ok(HirExpr::AdditionAssignment(
+            Box::new(lower_expr(*a)?),
+            Box::new(lower_expr(*b)?),
+        )),
+        AstExpr::SubtractionAssignment(a, b) => Ok(HirExpr::SubtractionAssignment(
+            Box::new(lower_expr(*a)?),
+            Box::new(lower_expr(*b)?),
+        )),
+        AstExpr::MultiplicationAssignment(a, b) => Ok(HirExpr::MultiplicationAssignment(
+            Box::new(lower_expr(*a)?),
+            Box::new(lower_expr(*b)?),
+        )),
+        AstExpr::DivisionAssignment(a, b) => Ok(HirExpr::DivisionAssignment(
+            Box::new(lower_expr(*a)?),
+            Box::new(lower_expr(*b)?),
+        )),
+        AstExpr::ModuloAssignment(a, b) => Ok(HirExpr::ModuloAssignment(
+            Box::new(lower_expr(*a)?),
+            Box::new(lower_expr(*b)?),
+        )),
+        AstExpr::BitwiseAndAssignment(a, b) => Ok(HirExpr::BitwiseAndAssignment(
+            Box::new(lower_expr(*a)?),
+            Box::new(lower_expr(*b)?),
+        )),
+        AstExpr::BitwiseOrAssignment(a, b) => Ok(HirExpr::BitwiseOrAssignment(
+            Box::new(lower_expr(*a)?),
+            Box::new(lower_expr(*b)?),
+        )),
+        AstExpr::BitwiseXorAssignment(a, b) => Ok(HirExpr::BitwiseXorAssignment(
+            Box::new(lower_expr(*a)?),
+            Box::new(lower_expr(*b)?),
+        )),
+        AstExpr::BitwiseLeftShiftAssignment(a, b) => Ok(HirExpr::BitwiseLeftShiftAssignment(
+            Box::new(lower_expr(*a)?),
+            Box::new(lower_expr(*b)?),
+        )),
+        AstExpr::BitwiseRightShiftAssignment(a, b) => Ok(HirExpr::BitwiseRightShiftAssignment(
+            Box::new(lower_expr(*a)?),
+            Box::new(lower_expr(*b)?),
+        )),
+        AstExpr::UnaryNot(a) => Ok(HirExpr::UnaryNot(Box::new(lower_expr(*a)?))),
+        AstExpr::UnaryBitwiseNot(a) => Ok(HirExpr::UnaryBitwiseNot(Box::new(lower_expr(*a)?))),
+        AstExpr::UnaryMinus(a) => Ok(HirExpr::UnaryMinus(Box::new(lower_expr(*a)?))),
+        AstExpr::UnaryAddressOf(a) => Ok(HirExpr::UnaryAddressOf(Box::new(lower_expr(*a)?))),
+        AstExpr::UnaryDereference(a) => Ok(HirExpr::UnaryDereference(Box::new(lower_expr(*a)?))),
+        AstExpr::Index(a, b) => Ok(HirExpr::Index(
+            Box::new(lower_expr(*a)?),
+            Box::new(lower_expr(*b)?),
+        )),
+        AstExpr::Dot(a, b) => Ok(HirExpr::Dot(Box::new(lower_expr(*a)?), b)),
+        AstExpr::Arrow(a, b) => Ok(HirExpr::Arrow(Box::new(lower_expr(*a)?), b)),
+        AstExpr::Call(a, b) => Ok(HirExpr::Call(
+            Box::new(lower_expr(*a)?),
+            b.into_iter()
+                .map(|e| lower_expr(e))
+                .collect::<Result<Vec<_>, _>>()?,
+        )),
+        AstExpr::Ternary(a, b, c) => Ok(HirExpr::Ternary(
+            Box::new(lower_expr(*a)?),
+            Box::new(lower_expr(*b)?),
+            Box::new(lower_expr(*c)?),
+        )),
+        AstExpr::LogicalAnd(a, b) => Ok(HirExpr::LogicalAnd(
+            Box::new(lower_expr(*a)?),
+            Box::new(lower_expr(*b)?),
+        )),
+        AstExpr::LogicalOr(a, b) => Ok(HirExpr::LogicalOr(
+            Box::new(lower_expr(*a)?),
+            Box::new(lower_expr(*b)?),
+        )),
+        AstExpr::Equals(a, b) => Ok(HirExpr::Equals(
+            Box::new(lower_expr(*a)?),
+            Box::new(lower_expr(*b)?),
+        )),
+        AstExpr::NotEquals(a, b) => Ok(HirExpr::NotEquals(
+            Box::new(lower_expr(*a)?),
+            Box::new(lower_expr(*b)?),
+        )),
+        AstExpr::BitwiseAnd(a, b) => Ok(HirExpr::BitwiseAnd(
+            Box::new(lower_expr(*a)?),
+            Box::new(lower_expr(*b)?),
+        )),
+        AstExpr::BitwiseOr(a, b) => Ok(HirExpr::BitwiseOr(
+            Box::new(lower_expr(*a)?),
+            Box::new(lower_expr(*b)?),
+        )),
+        AstExpr::BitwiseXor(a, b) => Ok(HirExpr::BitwiseXor(
+            Box::new(lower_expr(*a)?),
+            Box::new(lower_expr(*b)?),
+        )),
+        AstExpr::GreaterThan(a, b) => Ok(HirExpr::GreaterThan(
+            Box::new(lower_expr(*a)?),
+            Box::new(lower_expr(*b)?),
+        )),
+        AstExpr::GreaterThanOrEqualTo(a, b) => Ok(HirExpr::GreaterThanOrEqualTo(
+            Box::new(lower_expr(*a)?),
+            Box::new(lower_expr(*b)?),
+        )),
+        AstExpr::LessThan(a, b) => Ok(HirExpr::LessThan(
+            Box::new(lower_expr(*a)?),
+            Box::new(lower_expr(*b)?),
+        )),
+        AstExpr::LessThanOrEqualTo(a, b) => Ok(HirExpr::LessThanOrEqualTo(
+            Box::new(lower_expr(*a)?),
+            Box::new(lower_expr(*b)?),
+        )),
+        AstExpr::BitwiseRightShift(a, b) => Ok(HirExpr::BitwiseRightShift(
+            Box::new(lower_expr(*a)?),
+            Box::new(lower_expr(*b)?),
+        )),
+        AstExpr::BitwiseLeftShift(a, b) => Ok(HirExpr::BitwiseLeftShift(
+            Box::new(lower_expr(*a)?),
+            Box::new(lower_expr(*b)?),
+        )),
+        AstExpr::Addition(a, b) => Ok(HirExpr::Addition(
+            Box::new(lower_expr(*a)?),
+            Box::new(lower_expr(*b)?),
+        )),
+        AstExpr::Subtraction(a, b) => Ok(HirExpr::Subtraction(
+            Box::new(lower_expr(*a)?),
+            Box::new(lower_expr(*b)?),
+        )),
+        AstExpr::Multiplication(a, b) => Ok(HirExpr::Multiplication(
+            Box::new(lower_expr(*a)?),
+            Box::new(lower_expr(*b)?),
+        )),
+        AstExpr::Division(a, b) => Ok(HirExpr::Division(
+            Box::new(lower_expr(*a)?),
+            Box::new(lower_expr(*b)?),
+        )),
+        AstExpr::Modulo(a, b) => Ok(HirExpr::Modulo(
+            Box::new(lower_expr(*a)?),
+            Box::new(lower_expr(*b)?),
+        )),
+        AstExpr::NumberLiteral(n) => Ok(HirExpr::NumberLiteral(n)),
+        AstExpr::StringLiteral(s) => Ok(HirExpr::StringLiteral(s)),
+        AstExpr::Identifier(i) => Ok(HirExpr::Identifier(i)),
+        AstExpr::BooleanLiteral(b) => Ok(HirExpr::BooleanLiteral(b)),
+    }
+}
+
+pub fn lower_ty(ty: zrc_parser::ast::ty::Type) -> super::hir::ty::Type {
+    use super::hir::ty::Type as HirType;
+    use zrc_parser::ast::ty::Type as AstType;
+
+    match ty {
+        AstType::Identifier(x) => HirType::Identifier(x),
+    }
+}
+
+pub fn lower_program(
+    program: Vec<zrc_parser::ast::stmt::Declaration>,
+) -> Result<Vec<super::hir::stmt::Declaration>, String> {
+    use super::hir::stmt::ArgumentDeclaration as HirArgumentDeclaration;
+    use super::hir::stmt::Declaration as HirDeclaration;
+    use super::hir::stmt::LetDeclaration as HirLetDeclaration;
+    use zrc_parser::ast::stmt::Declaration as AstDeclaration;
+
+    program
+        .into_iter()
+        .map(|declaration| -> Result<HirDeclaration, String> {
+            Ok(match declaration {
+                AstDeclaration::DeclarationList(declarations) => HirDeclaration::DeclarationList(
+                    declarations
+                        .into_iter()
+                        .map(|declaration| -> Result<HirLetDeclaration, String> {
+                            Ok(HirLetDeclaration {
+                                name: declaration.name,
+                                ty: declaration.ty.map(lower_ty),
+                                value: declaration.value.map(lower_expr).transpose()?,
+                            })
+                        })
+                        .collect::<Result<Vec<_>, _>>()?,
+                ),
+
+                AstDeclaration::FunctionDefinition {
+                    name,
+                    parameters,
+                    return_type,
+                    body,
+                } => HirDeclaration::FunctionDefinition {
+                    name,
+                    parameters: parameters
+                        .into_iter()
+                        .map(|argument| HirArgumentDeclaration {
+                            name: argument.name,
+                            ty: argument.ty.map(lower_ty),
+                        })
+                        .collect(),
+                    return_type: return_type.map(lower_ty),
+                    body: lower_block(body)?,
+                },
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()
+}
+
+pub fn lower_block(
+    block: Vec<zrc_parser::ast::stmt::Stmt>,
+) -> Result<Vec<super::hir::stmt::Stmt>, String> {
+    use super::hir::expr::Expr as HirExpr;
+    use super::hir::stmt::Stmt as HirStmt;
+    use zrc_parser::ast::expr::Expr as AstExpr;
+    use zrc_parser::ast::stmt::Stmt as AstStmt;
+
+    block
+        .into_iter()
+        .map(|stmt| -> Result<HirStmt, String> {
+            Ok(match stmt {
+                AstStmt::IfStmt(cond, then) => HirStmt::IfStmt {
+                    cond: lower_expr(cond)?,
+                    then: lower_block(vec![*then])?, // implicitly wrap in a block. if (x) y; becomes if (x) {y;}. Technically if (x) {y;} becomes if (x) {{y;}} but that's mainly unimportant.
+                    then_else: None,
+                },
+
+                AstStmt::IfElseStmt(cond, then, then_else) => HirStmt::IfStmt {
+                    cond: lower_expr(cond)?,
+                    then: lower_block(vec![*then])?,
+                    then_else: Some(lower_block(vec![*then_else])?),
+                },
+
+                // Infinite loops are desugared to just that -- infinite loops.
+                AstStmt::WhileStmt(AstExpr::BooleanLiteral(true), stmt) => {
+                    HirStmt::InfiniteLoop(lower_block(vec![*stmt])?) // same block magic
+                }
+
+                // While loops with a condition desugar to an infinite loop with a break condition.
+                AstStmt::WhileStmt(cond, stmt) => HirStmt::InfiniteLoop(vec![HirStmt::IfStmt {
+                    cond: HirExpr::UnaryNot(Box::new(lower_expr(cond)?)),
+                    then: vec![HirStmt::BreakStmt],
+                    then_else: Some(lower_block(vec![*stmt])?),
+                }]),
+
+                // And for loops are desugared as well.
+                // for (init; cond; post) { body; }
+                // becomes:
+                // { // for scoping so init doesn't leak into parent scope
+                //     init;
+                //     while (cond) {
+                //         { body; } // again ot prevent scope leak
+                //         post;
+                //     }
+                // }
+                //
+                // Be aware this recurses. Don't use ForStmt anywhere below or you may end up in infinite recursion.
+                AstStmt::ForStmt {
+                    init,
+                    cond,
+                    post,
+                    body,
+                } => HirStmt::BlockStmt(lower_block(vec![
+                    AstStmt::Declaration(*init),
+                    AstStmt::WhileStmt(
+                        cond,
+                        Box::new(AstStmt::BlockStmt(vec![
+                            AstStmt::BlockStmt(vec![*body]),
+                            AstStmt::ExprStmt(post),
+                        ])),
+                    ),
+                ])?),
+
+                AstStmt::BlockStmt(stmts) => HirStmt::BlockStmt(lower_block(stmts)?),
+
+                AstStmt::ExprStmt(expr) => HirStmt::ExprStmt(lower_expr(expr)?),
+
+                AstStmt::BreakStmt => HirStmt::BreakStmt,
+                AstStmt::ContinueStmt => HirStmt::ContinueStmt,
+                AstStmt::EmptyStmt => HirStmt::EmptyStmt,
+                AstStmt::ReturnStmt(x) => HirStmt::ReturnStmt(x.map(lower_expr).transpose()?),
+                AstStmt::Declaration(declaration) => {
+                    HirStmt::Declaration(lower_program(vec![declaration])?[0].clone())
+                }
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn desugaring_works_as_expected() {
+        use super::super::hir::{
+            expr::Expr,
+            stmt::{Declaration, LetDeclaration, Stmt},
+            ty::Type,
+        };
+
+        println!(
+            "{}",
+            lower_program(
+                zrc_parser::parser::parse_program(concat!(
+                    "fn main() -> i32 {\n",
+                    "  if (x) y;\n",
+                    "  while (true) y;\n",
+                    "  while (x) y;\n",
+                    "  for (let i = 0; cond; post) body;\n",
+                    "}"
+                ))
+                .unwrap()
+            )
+            .unwrap()
+            .into_iter()
+            .map(|x| x.to_string())
+            .collect::<Vec<_>>()
+            .join("\n")
+        );
+
+        assert_eq!(
+            lower_program(
+                zrc_parser::parser::parse_program(concat!(
+                    "fn main() -> i32 {\n",
+                    "  if (x) y;\n",
+                    "  while (true) y;\n",
+                    "  while (x) y;\n",
+                    "  for (let i = 0; cond; post) body;\n",
+                    "}"
+                ))
+                .unwrap()
+            ),
+            Ok(vec![Declaration::FunctionDefinition {
+                name: "main".to_string(),
+                parameters: vec![],
+                return_type: Some(Type::Identifier("i32".to_string())),
+                body: vec![
+                    Stmt::IfStmt {
+                        cond: Expr::Identifier("x".to_string()),
+                        // implicitly wrapped in block
+                        then: vec![Stmt::ExprStmt(Expr::Identifier("y".to_string()))],
+                        then_else: None,
+                    },
+                    // also wrapped in implicit box
+                    Stmt::InfiniteLoop(vec![Stmt::ExprStmt(Expr::Identifier("y".to_string()))]),
+                    // desugared to infinite loop
+                    Stmt::InfiniteLoop(vec![Stmt::IfStmt {
+                        cond: Expr::UnaryNot(Box::new(Expr::Identifier("x".to_string()))),
+                        then: vec![Stmt::BreakStmt],
+                        then_else: Some(vec![Stmt::ExprStmt(Expr::Identifier("y".to_string()))])
+                    }]),
+                    // desugared to infinite loop as well
+                    Stmt::BlockStmt(vec![
+                        Stmt::Declaration(Declaration::DeclarationList(vec![LetDeclaration {
+                            name: "i".to_string(),
+                            ty: None,
+                            value: Some(Expr::NumberLiteral("0".to_string()))
+                        },])),
+                        Stmt::InfiniteLoop(vec![Stmt::IfStmt {
+                            cond: Expr::UnaryNot(Box::new(Expr::Identifier("cond".to_string()))),
+                            then: vec![Stmt::BreakStmt],
+                            then_else: Some(vec![Stmt::BlockStmt(vec![
+                                Stmt::BlockStmt(vec![Stmt::ExprStmt(Expr::Identifier(
+                                    "body".to_string()
+                                ))]),
+                                Stmt::ExprStmt(Expr::Identifier("post".to_string()))
+                            ])])
+                        }])
+                    ])
+                ]
+            }])
+        )
+    }
+}

--- a/compiler/zrc_parser/src/internal_parser.lalrpop
+++ b/compiler/zrc_parser/src/internal_parser.lalrpop
@@ -39,7 +39,8 @@ OpenStmt: Stmt = {
     "if" "(" <a:Expr> ")" <b:ClosedStmt> "else" <c:OpenStmt> => 
         Stmt::IfElseStmt(a, Box::new(b), Box::new(c)),
     "while" "(" <a:Expr> ")" <b:OpenStmt> => Stmt::WhileStmt(a, Box::new(b)),
-    "for" "(" <a:Declaration> ";" <b:Expr> ";" <c:Expr> ")" <d:OpenStmt> => Stmt::ForStmt {
+    // The declarations include the semicolon for us.
+    "for" "(" <a:Declaration> <b:Expr> ";" <c:Expr> ")" <d:OpenStmt> => Stmt::ForStmt {
         init: Box::new(a),
         cond: b,
         post: c,
@@ -52,7 +53,8 @@ ClosedStmt: Stmt = {
     "if" "(" <a:Expr> ")" <b:ClosedStmt> "else" <c:ClosedStmt> =>
         Stmt::IfElseStmt(a, Box::new(b), Box::new(c)),
     "while" "(" <a:Expr> ")" <b:ClosedStmt> => Stmt::WhileStmt(a, Box::new(b)),
-    "for" "(" <a:Declaration> ";" <b:Expr> ";" <c:Expr> ")" <d:ClosedStmt> => Stmt::ForStmt {
+    // The declarations include the semicolon for us.
+    "for" "(" <a:Declaration> <b:Expr> ";" <c:Expr> ")" <d:ClosedStmt> => Stmt::ForStmt {
         init: Box::new(a),
         cond: b,
         post: c,


### PR DESCRIPTION
This adds a Zirco high-level intermediate representation (HIR). This then would be run through typeck to get the THIR (typed HIR) which can then move to MIR which is just basic blocks before LLVM processing. This is similar to the Rust pipeline.

All implicit blocks become explicit, loops are all desugared to infinite loops.

Input code:
```rs
fn main() -> i32 {
    if (x) y;
    while (true) y;
    while (x) y;
    for (let i = 0; cond; post) body;
}
```

After [Code -> AST -> THIR -> Code] re-stringification:
```
fn main() -> i32 { if ((x)) { (y); } while (true) { (y); } while (true) { if ((!(x))) { break; } else { (y); } } {let i = (0);while (true) { if ((!(cond))) { break; } else { {{(body);}(post);} } }} }
```