### PR TITLE
refactor: make primitive types live in a default scope

### DIFF
--- a/compiler/zrc_typeck/src/tast/ty.rs
+++ b/compiler/zrc_typeck/src/tast/ty.rs
@@ -7,6 +7,7 @@ use crate::typeck::BlockReturnType;
 /// The possible Zirco types
 #[derive(PartialEq, Debug, Clone)]
 pub enum Type {
+    // WHENEVER ADDING NEW PRIMITIVES HERE, ADD THEM TO THE TYPE SCOPE IN [`zrc_typeck::typeck::Scope::default`].
     /// `i8`
     I8,
     /// `u8`

--- a/compiler/zrc_typeck/src/tast/ty.rs
+++ b/compiler/zrc_typeck/src/tast/ty.rs
@@ -7,7 +7,8 @@ use crate::typeck::BlockReturnType;
 /// The possible Zirco types
 #[derive(PartialEq, Debug, Clone)]
 pub enum Type {
-    // WHENEVER ADDING NEW PRIMITIVES HERE, ADD THEM TO THE TYPE SCOPE IN [`zrc_typeck::typeck::Scope::default`].
+    // WHENEVER ADDING NEW PRIMITIVES HERE, ADD THEM TO THE TYPE SCOPE IN
+    // [`zrc_typeck::typeck::Scope::default`].
     /// `i8`
     I8,
     /// `u8`

--- a/compiler/zrc_typeck/src/typeck.rs
+++ b/compiler/zrc_typeck/src/typeck.rs
@@ -37,8 +37,8 @@ impl Scope {
     #[must_use]
     pub fn new_empty() -> Self {
         Self {
-            type_scope: HashMap::new(),
             value_scope: HashMap::new(),
+            type_scope: HashMap::new(),
         }
     }
 

--- a/compiler/zrc_typeck/src/typeck.rs
+++ b/compiler/zrc_typeck/src/typeck.rs
@@ -27,12 +27,18 @@ pub struct Scope {
     type_scope: HashMap<String, TastType>,
 }
 impl Scope {
-    /// Creates a new Scope with no values or types.
+    /// Creates a new Scope from just the defaults
     #[must_use]
     pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Creates a new Scope without the primitives
+    #[must_use]
+    pub fn new_empty() -> Self {
         Self {
-            value_scope: HashMap::new(),
             type_scope: HashMap::new(),
+            value_scope: HashMap::new(),
         }
     }
 
@@ -71,9 +77,24 @@ impl Scope {
         self.type_scope.insert(identifier, ty);
     }
 }
+
 impl Default for Scope {
     fn default() -> Self {
-        Self::new()
+        Self::from_scopes(
+            HashMap::from([]),
+            HashMap::from([
+                ("i8".to_string(), TastType::I8),
+                ("u8".to_string(), TastType::U8),
+                ("i16".to_string(), TastType::I16),
+                ("u16".to_string(), TastType::U16),
+                ("i32".to_string(), TastType::I32),
+                ("u32".to_string(), TastType::U32),
+                ("i64".to_string(), TastType::I64),
+                ("u64".to_string(), TastType::U64),
+                ("bool".to_string(), TastType::Bool),
+                // void is not producible
+            ]),
+        )
     }
 }
 

--- a/compiler/zrc_typeck/src/typeck/ty.rs
+++ b/compiler/zrc_typeck/src/typeck/ty.rs
@@ -17,27 +17,16 @@ pub fn resolve_type(
     ty: ParserType,
 ) -> Result<TastType, zrc_diagnostics::Diagnostic> {
     Ok(match ty.0.value() {
-        ParserTypeKind::Identifier(x) => match x.as_str() {
-            "i8" => TastType::I8,
-            "u8" => TastType::U8,
-            "i16" => TastType::I16,
-            "u16" => TastType::U16,
-            "i32" => TastType::I32,
-            "u32" => TastType::U32,
-            "i64" => TastType::I64,
-            "u64" => TastType::U64,
-            "bool" => TastType::Bool,
-            _ => {
-                if let Some(t) = scope.get_type(x) {
-                    t.clone()
-                } else {
-                    return Err(Diagnostic(
-                        zrc_diagnostics::Severity::Error,
-                        ty.0.map(|x| DiagnosticKind::UnableToResolveType(x.to_string())),
-                    ));
-                }
+        ParserTypeKind::Identifier(x) => {
+            if let Some(t) = scope.get_type(x) {
+                t.clone()
+            } else {
+                return Err(Diagnostic(
+                    zrc_diagnostics::Severity::Error,
+                    ty.0.map(|x| DiagnosticKind::UnableToResolveType(x.to_string())),
+                ));
             }
-        },
+        }
         ParserTypeKind::Ptr(t) => TastType::Ptr(Box::new(resolve_type(scope, *t.clone())?)),
         ParserTypeKind::Struct(members) => TastType::Struct(
             members


### PR DESCRIPTION
this prevents primitives from being overwritten, hence Fixes #37