### PR TITLE
feat: allow booleans as equality operands

### DIFF
--- a/compiler/zrc_diagnostics/src/lib.rs
+++ b/compiler/zrc_diagnostics/src/lib.rs
@@ -111,6 +111,7 @@ pub enum DiagnosticKind {
 }
 
 impl Display for DiagnosticKind {
+    #[allow(clippy::too_many_lines)]
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::UnknownToken(c) => write!(f, "unknown token `{c}`"),
@@ -197,7 +198,11 @@ impl Display for DiagnosticKind {
             }
             Self::EqualityOperators(t1, t2) => write!(
                 f,
-                "expected both sides to be the same integer, boolean or pointer type, got `{t1}` and `{t2}`"
+                concat!(
+                    "expected both sides to be the same integer,",
+                    " boolean or pointer type, got `{}` and `{}`"
+                ),
+                t1, t2
             ),
             Self::InvalidCast(from, to) => write!(f, "cannot cast `{from}` to `{to}`"),
             Self::IdentifierAlreadyInUse(i) => write!(f, "identifier `{i}` already in use"),

--- a/compiler/zrc_diagnostics/src/lib.rs
+++ b/compiler/zrc_diagnostics/src/lib.rs
@@ -197,7 +197,7 @@ impl Display for DiagnosticKind {
             }
             Self::EqualityOperators(t1, t2) => write!(
                 f,
-                "expected both sides to be the same integer or pointer type, got `{t1}` and `{t2}`"
+                "expected both sides to be the same integer, boolean or pointer type, got `{t1}` and `{t2}`"
             ),
             Self::InvalidCast(from, to) => write!(f, "cannot cast `{from}` to `{to}`"),
             Self::IdentifierAlreadyInUse(i) => write!(f, "identifier `{i}` already in use"),

--- a/compiler/zrc_typeck/src/typeck/expr.rs
+++ b/compiler/zrc_typeck/src/typeck/expr.rs
@@ -351,6 +351,8 @@ pub fn type_expr(scope: &Scope, expr: Expr) -> Result<TypedExpr, zrc_diagnostics
                 // int == int is valid
             } else if let (TastType::Ptr(_), TastType::Ptr(_)) = (at.0.clone(), bt.0.clone()) {
                 // *T == *U is valid
+            } else if at.0 == TastType::Bool && bt.0 == TastType::Bool {
+                // bool == bool is valid
             } else {
                 return Err(Diagnostic(
                     Severity::Error,


### PR DESCRIPTION
This allows `bool`s to be used as the left/right operands of `==`.

Closes #51