### PR TITLE
make `&` only accept lvalues

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,6 +4,7 @@
         "bitcast",
         "inttoptr",
         "lalrpop",
+        "Lvalue",
         "ptrtoint",
         "sdiv",
         "Spannable",

--- a/compiler/zrc_codegen/src/expr.rs
+++ b/compiler/zrc_codegen/src/expr.rs
@@ -391,7 +391,7 @@ pub fn cg_expr(
         }
 
         TypedExprKind::UnaryAddressOf(x) => {
-            let (x_ptr, bb) = cg_expr(module, cg, bb, scope, *x)?;
+            let (x_ptr, bb) = cg_place(module, cg, bb, scope, *x)?;
 
             let result_typename = get_llvm_typename(expr.0.clone());
 

--- a/compiler/zrc_diagnostics/src/lib.rs
+++ b/compiler/zrc_diagnostics/src/lib.rs
@@ -72,7 +72,7 @@ pub enum DiagnosticKind {
     // TYPE CHECKER ERRORS
     UnableToResolveType(String),
     UnableToResolveIdentifier(String),
-    AssignmentToNonPlace(String),
+    NotAnLvalue(String),
     InvalidAssignmentRightHandSideType {
         expected: String,
         got: String,
@@ -144,8 +144,11 @@ impl Display for DiagnosticKind {
             Self::UnableToResolveIdentifier(i) => {
                 write!(f, "unable to resolve identifier `{i}`")
             }
-            Self::AssignmentToNonPlace(expr) => {
-                write!(f, "cannot assign to non-place expression `{expr}`")
+            Self::NotAnLvalue(expr) => {
+                write!(
+                    f,
+                    "`{expr}` is not a valid lvalue for assignment or address-of"
+                )
             }
             Self::InvalidAssignmentRightHandSideType { expected, got } => write!(
                 f,

--- a/compiler/zrc_typeck/src/tast/expr.rs
+++ b/compiler/zrc_typeck/src/tast/expr.rs
@@ -63,7 +63,7 @@ pub enum TypedExprKind<'input> {
     /// `-x`
     UnaryMinus(Box<TypedExpr<'input>>),
     /// `&x`
-    UnaryAddressOf(Box<TypedExpr<'input>>),
+    UnaryAddressOf(Box<Place<'input>>),
     /// `*x`
     UnaryDereference(Box<TypedExpr<'input>>),
 

--- a/compiler/zrc_typeck/src/typeck/expr.rs
+++ b/compiler/zrc_typeck/src/typeck/expr.rs
@@ -53,7 +53,7 @@ fn expr_to_place(span: Span, expr: TypedExpr) -> Result<Place, zrc_diagnostics::
         _ => {
             return Err(zrc_diagnostics::Diagnostic(
                 zrc_diagnostics::Severity::Error,
-                span.containing(DiagnosticKind::AssignmentToNonPlace(expr.to_string())),
+                span.containing(DiagnosticKind::NotAnLvalue(expr.to_string())),
             ))
         }
     })
@@ -143,7 +143,7 @@ pub fn type_expr<'input>(
             let t = type_expr(scope, *x)?;
             TypedExpr(
                 TastType::Ptr(Box::new(t.0.clone())),
-                TypedExprKind::UnaryAddressOf(Box::new(t)),
+                TypedExprKind::UnaryAddressOf(Box::new(expr_to_place(expr_span, t)?)),
             )
         }
         ExprKind::UnaryDereference(x) => {


### PR DESCRIPTION
Makes it so that the right hand side of `&` can only accept valid lvalues.