### PR TITLE
enable `unused_qualifications` lint

### DIFF
--- a/compiler/zrc/src/main.rs
+++ b/compiler/zrc/src/main.rs
@@ -39,7 +39,8 @@
     non_exhaustive_omitted_patterns,
     unsafe_op_in_unsafe_fn,
     unused_crate_dependencies,
-    variant_size_differences
+    variant_size_differences,
+    unused_qualifications
 )]
 #![allow(clippy::multiple_crate_versions, clippy::cargo_common_metadata)]
 

--- a/compiler/zrc_codegen/src/lib.rs
+++ b/compiler/zrc_codegen/src/lib.rs
@@ -40,6 +40,7 @@
     unsafe_op_in_unsafe_fn,
     unused_crate_dependencies,
     variant_size_differences,
+    unused_qualifications,
 
     // These should be enabled in any non-user-facing code, like the parser, but not in the
     // frontend.

--- a/compiler/zrc_diagnostics/src/lib.rs
+++ b/compiler/zrc_diagnostics/src/lib.rs
@@ -40,6 +40,7 @@
     unsafe_op_in_unsafe_fn,
     unused_crate_dependencies,
     variant_size_differences,
+    unused_qualifications,
 
     // These should be enabled in any non-user-facing code, like the parser, but not in the
     // frontend.

--- a/compiler/zrc_parser/src/ast/stmt.rs
+++ b/compiler/zrc_parser/src/ast/stmt.rs
@@ -77,7 +77,7 @@ pub enum Declaration<'input> {
         name: Spanned<&'input str>,
         /// The key-value pairs of the struct. Ordered by declaration order.
         #[allow(clippy::type_complexity)]
-        fields: Spanned<Vec<Spanned<(Spanned<&'input str>, super::ty::Type<'input>)>>>,
+        fields: Spanned<Vec<Spanned<(Spanned<&'input str>, Type<'input>)>>>,
     },
 }
 

--- a/compiler/zrc_parser/src/lexer.rs
+++ b/compiler/zrc_parser/src/lexer.rs
@@ -74,7 +74,7 @@ pub enum LexicalError<'input> {
 /// A lexer callback helper to obtain the currently matched token slice.
 fn lexer_slice<'input, T: Logos<'input>>(
     lex: &Lexer<'input, T>,
-) -> &'input <<T as logos::Logos<'input>>::Source as logos::Source>::Slice {
+) -> &'input <<T as Logos<'input>>::Source as logos::Source>::Slice {
     lex.slice()
 }
 

--- a/compiler/zrc_parser/src/lib.rs
+++ b/compiler/zrc_parser/src/lib.rs
@@ -40,6 +40,7 @@
     unsafe_op_in_unsafe_fn,
     unused_crate_dependencies,
     variant_size_differences,
+    unused_qualifications,
 
     // These should be enabled in any non-user-facing code, like the parser, but not in the
     // frontend.
@@ -65,7 +66,8 @@ lalrpop_mod!(
         clippy::pedantic,
         missing_docs,
         clippy::missing_docs_in_private_items,
-        clippy::restriction
+        clippy::restriction,
+        unused_qualifications
     )]
     internal_parser
 );

--- a/compiler/zrc_parser/src/parser.rs
+++ b/compiler/zrc_parser/src/parser.rs
@@ -32,7 +32,7 @@ use crate::{internal_parser, lexer::LexicalError};
 
 /// Converts from a LALRPOP [`ParseError`] to a corresponding [`Diagnostic`].
 fn parser_error_to_diagnostic(
-    error: ParseError<usize, lexer::Tok, Spanned<lexer::LexicalError>>,
+    error: ParseError<usize, lexer::Tok, Spanned<LexicalError>>,
 ) -> Diagnostic {
     match error {
         ParseError::InvalidToken { location } => Diagnostic(
@@ -97,8 +97,8 @@ fn parser_error_to_diagnostic(
 /// [`Spanned<Result<Tok, LexicalError>>`] to something suitable to pass to
 /// LALRPOP.
 fn zirco_lexer_span_to_lalrpop_span<'input>(
-    spanned: Spanned<Result<lexer::Tok<'input>, lexer::LexicalError<'input>>>,
-) -> Result<(usize, lexer::Tok<'input>, usize), Spanned<lexer::LexicalError<'input>>> {
+    spanned: Spanned<Result<lexer::Tok<'input>, LexicalError<'input>>>,
+) -> Result<(usize, lexer::Tok<'input>, usize), Spanned<LexicalError<'input>>> {
     spanned.transpose().map(|spanned_tok| {
         let span = spanned_tok.span();
         (span.start(), spanned_tok.into_value(), span.end())

--- a/compiler/zrc_typeck/src/lib.rs
+++ b/compiler/zrc_typeck/src/lib.rs
@@ -44,6 +44,7 @@
     unsafe_op_in_unsafe_fn,
     unused_crate_dependencies,
     variant_size_differences,
+    unused_qualifications,
 
     // These should be enabled in any non-user-facing code, like the parser, but not in the
     // frontend.

--- a/compiler/zrc_typeck/src/tast/stmt.rs
+++ b/compiler/zrc_typeck/src/tast/stmt.rs
@@ -92,7 +92,7 @@ pub enum TypedDeclaration<'input> {
         /// The name of the newtype.
         name: &'input str,
         /// The key-value pairs of the struct. Ordered by declaration order.
-        fields: IndexMap<&'input str, super::ty::Type<'input>>,
+        fields: IndexMap<&'input str, Type<'input>>,
     },
 }
 

--- a/compiler/zrc_typeck/src/typeck/block.rs
+++ b/compiler/zrc_typeck/src/typeck/block.rs
@@ -111,7 +111,7 @@ fn coerce_stmt_into_block(stmt: Stmt<'_>) -> Spanned<Vec<Stmt<'_>>> {
 fn process_let_declaration<'input>(
     scope: &mut Scope<'input>,
     declarations: Vec<Spanned<AstLetDeclaration<'input>>>,
-) -> Result<Vec<TastLetDeclaration<'input>>, zrc_diagnostics::Diagnostic> {
+) -> Result<Vec<TastLetDeclaration<'input>>, Diagnostic> {
     declarations
         .into_iter()
         .map(
@@ -213,7 +213,7 @@ fn process_let_declaration<'input>(
 pub fn process_declaration<'input>(
     global_scope: &mut Scope<'input>,
     declaration: AstDeclaration<'input>,
-) -> Result<TypedDeclaration<'input>, zrc_diagnostics::Diagnostic> {
+) -> Result<TypedDeclaration<'input>, Diagnostic> {
     Ok(match declaration {
         AstDeclaration::FunctionDeclaration {
             parameters,
@@ -377,7 +377,7 @@ pub fn type_block<'input>(
     input_block: Spanned<Vec<Stmt<'input>>>,
     can_use_break_continue: bool,
     return_ability: BlockReturnAbility,
-) -> Result<(Vec<TypedStmt<'input>>, BlockReturnActuality), zrc_diagnostics::Diagnostic> {
+) -> Result<(Vec<TypedStmt<'input>>, BlockReturnActuality), Diagnostic> {
     let mut scope: Scope<'input> = parent_scope.clone();
 
     let input_block_span = input_block.span();

--- a/compiler/zrc_typeck/src/typeck/expr.rs
+++ b/compiler/zrc_typeck/src/typeck/expr.rs
@@ -44,7 +44,7 @@ fn desugar_assignment<'input>(
 }
 
 /// Validate an expr into a place
-fn expr_to_place(span: Span, expr: TypedExpr) -> Result<Place, zrc_diagnostics::Diagnostic> {
+fn expr_to_place(span: Span, expr: TypedExpr) -> Result<Place, Diagnostic> {
     #[allow(clippy::wildcard_enum_match_arm)]
     Ok(match expr.1 {
         TypedExprKind::UnaryDereference(x) => Place(expr.0, PlaceKind::Deref(x)),
@@ -52,8 +52,8 @@ fn expr_to_place(span: Span, expr: TypedExpr) -> Result<Place, zrc_diagnostics::
         TypedExprKind::Index(x, y) => Place(expr.0, PlaceKind::Index(x, y)),
         TypedExprKind::Dot(x, y) => Place(expr.0, PlaceKind::Dot(x, y)),
         _ => {
-            return Err(zrc_diagnostics::Diagnostic(
-                zrc_diagnostics::Severity::Error,
+            return Err(Diagnostic(
+                Severity::Error,
                 span.containing(DiagnosticKind::NotAnLvalue(expr.to_string())),
             ))
         }
@@ -72,7 +72,7 @@ fn expr_to_place(span: Span, expr: TypedExpr) -> Result<Place, zrc_diagnostics::
 pub fn type_expr<'input>(
     scope: &Scope<'input>,
     expr: Expr<'input>,
-) -> Result<TypedExpr<'input>, zrc_diagnostics::Diagnostic> {
+) -> Result<TypedExpr<'input>, Diagnostic> {
     let expr_span = expr.0.span();
     Ok(match expr.0.into_value() {
         ExprKind::Comma(lhs, rhs) => {
@@ -91,8 +91,8 @@ pub fn type_expr<'input>(
             let value_t = type_expr(scope, value)?;
 
             if place_t.0 != value_t.0 {
-                return Err(zrc_diagnostics::Diagnostic(
-                    zrc_diagnostics::Severity::Error,
+                return Err(Diagnostic(
+                    Severity::Error,
                     expr_span.containing(DiagnosticKind::InvalidAssignmentRightHandSideType {
                         expected: place_t.0.to_string(),
                         got: value_t.0.to_string(),

--- a/compiler/zrc_utils/src/lib.rs
+++ b/compiler/zrc_utils/src/lib.rs
@@ -33,6 +33,7 @@
     clippy::unimplemented,
     clippy::unneeded_field_pattern,
     clippy::wildcard_enum_match_arm,
+    unused_qualifications,
 
     // These should be enabled in any non-user-facing code, like the parser, but not in the
     // frontend.


### PR DESCRIPTION
Enables a new rustc lint, `unused_qualifications`, which lints against qualified paths that are already in scope.
