### PR TITLE
refactor: rename builder methods to be more distinct from rust std traits like eq

### DIFF
--- a/compiler/zrc_parser/src/ast/expr.rs
+++ b/compiler/zrc_parser/src/ast/expr.rs
@@ -293,7 +293,7 @@ impl<'input> Display for ExprKind<'input> {
 #[allow(clippy::should_implement_trait)]
 impl<'input> Expr<'input> {
     #[must_use]
-    pub fn comma(lhs: Self, rhs: Self) -> Self {
+    pub fn build_comma(lhs: Self, rhs: Self) -> Self {
         Self(spanned!(
             lhs.0.start(),
             ExprKind::Comma(Box::new(lhs), Box::new(rhs)),
@@ -301,7 +301,7 @@ impl<'input> Expr<'input> {
         ))
     }
 
-    fn assignment(assignment: Assignment, lhs: Self, rhs: Self) -> Self {
+    fn build_assignment(assignment: Assignment, lhs: Self, rhs: Self) -> Self {
         Self(spanned!(
             lhs.0.start(),
             ExprKind::Assignment(assignment, Box::new(lhs), Box::new(rhs)),
@@ -310,36 +310,36 @@ impl<'input> Expr<'input> {
     }
 
     #[must_use]
-    pub fn assign(lhs: Self, rhs: Self) -> Self {
-        Self::assignment(Assignment::Standard, lhs, rhs)
+    pub fn build_assign(lhs: Self, rhs: Self) -> Self {
+        Self::build_assignment(Assignment::Standard, lhs, rhs)
     }
 
-    fn arithmetic_assignment(arithmetic: Arithmetic, lhs: Self, rhs: Self) -> Self {
-        Self::assignment(Assignment::Arithmetic(arithmetic), lhs, rhs)
+    fn build_arithmetic_assignment(arithmetic: Arithmetic, lhs: Self, rhs: Self) -> Self {
+        Self::build_assignment(Assignment::Arithmetic(arithmetic), lhs, rhs)
     }
 
     #[must_use]
-    pub fn add_assign(lhs: Self, rhs: Self) -> Self {
-        Self::arithmetic_assignment(Arithmetic::Addition, lhs, rhs)
+    pub fn build_add_assign(lhs: Self, rhs: Self) -> Self {
+        Self::build_arithmetic_assignment(Arithmetic::Addition, lhs, rhs)
     }
     #[must_use]
-    pub fn sub_assign(lhs: Self, rhs: Self) -> Self {
-        Self::arithmetic_assignment(Arithmetic::Subtraction, lhs, rhs)
+    pub fn build_sub_assign(lhs: Self, rhs: Self) -> Self {
+        Self::build_arithmetic_assignment(Arithmetic::Subtraction, lhs, rhs)
     }
     #[must_use]
-    pub fn mul_assign(lhs: Self, rhs: Self) -> Self {
-        Self::arithmetic_assignment(Arithmetic::Multiplication, lhs, rhs)
+    pub fn build_mul_assign(lhs: Self, rhs: Self) -> Self {
+        Self::build_arithmetic_assignment(Arithmetic::Multiplication, lhs, rhs)
     }
     #[must_use]
-    pub fn div_assign(lhs: Self, rhs: Self) -> Self {
-        Self::arithmetic_assignment(Arithmetic::Division, lhs, rhs)
+    pub fn build_div_assign(lhs: Self, rhs: Self) -> Self {
+        Self::build_arithmetic_assignment(Arithmetic::Division, lhs, rhs)
     }
     #[must_use]
-    pub fn mod_assign(lhs: Self, rhs: Self) -> Self {
-        Self::arithmetic_assignment(Arithmetic::Modulo, lhs, rhs)
+    pub fn build_mod_assign(lhs: Self, rhs: Self) -> Self {
+        Self::build_arithmetic_assignment(Arithmetic::Modulo, lhs, rhs)
     }
 
-    fn binary_bitwise(op: BinaryBitwise, lhs: Self, rhs: Self) -> Self {
+    fn build_binary_bitwise(op: BinaryBitwise, lhs: Self, rhs: Self) -> Self {
         Self(spanned!(
             lhs.0.start(),
             ExprKind::BinaryBitwise(op, Box::new(lhs), Box::new(rhs)),
@@ -347,27 +347,27 @@ impl<'input> Expr<'input> {
         ))
     }
     #[must_use]
-    pub fn bit_and(lhs: Self, rhs: Self) -> Self {
-        Self::binary_bitwise(BinaryBitwise::And, lhs, rhs)
+    pub fn build_bit_and(lhs: Self, rhs: Self) -> Self {
+        Self::build_binary_bitwise(BinaryBitwise::And, lhs, rhs)
     }
     #[must_use]
-    pub fn bit_or(lhs: Self, rhs: Self) -> Self {
-        Self::binary_bitwise(BinaryBitwise::Or, lhs, rhs)
+    pub fn build_bit_or(lhs: Self, rhs: Self) -> Self {
+        Self::build_binary_bitwise(BinaryBitwise::Or, lhs, rhs)
     }
     #[must_use]
-    pub fn bit_xor(lhs: Self, rhs: Self) -> Self {
-        Self::binary_bitwise(BinaryBitwise::Xor, lhs, rhs)
+    pub fn build_bit_xor(lhs: Self, rhs: Self) -> Self {
+        Self::build_binary_bitwise(BinaryBitwise::Xor, lhs, rhs)
     }
     #[must_use]
-    pub fn shl(lhs: Self, rhs: Self) -> Self {
-        Self::binary_bitwise(BinaryBitwise::Shl, lhs, rhs)
+    pub fn build_shl(lhs: Self, rhs: Self) -> Self {
+        Self::build_binary_bitwise(BinaryBitwise::Shl, lhs, rhs)
     }
     #[must_use]
-    pub fn shr(lhs: Self, rhs: Self) -> Self {
-        Self::binary_bitwise(BinaryBitwise::Shr, lhs, rhs)
+    pub fn build_shr(lhs: Self, rhs: Self) -> Self {
+        Self::build_binary_bitwise(BinaryBitwise::Shr, lhs, rhs)
     }
 
-    fn logical(op: Logical, lhs: Self, rhs: Self) -> Self {
+    fn build_logical(op: Logical, lhs: Self, rhs: Self) -> Self {
         Self(spanned!(
             lhs.0.start(),
             ExprKind::Logical(op, Box::new(lhs), Box::new(rhs)),
@@ -375,15 +375,15 @@ impl<'input> Expr<'input> {
         ))
     }
     #[must_use]
-    pub fn logical_and(lhs: Self, rhs: Self) -> Self {
-        Self::logical(Logical::And, lhs, rhs)
+    pub fn build_logical_and(lhs: Self, rhs: Self) -> Self {
+        Self::build_logical(Logical::And, lhs, rhs)
     }
     #[must_use]
-    pub fn logical_or(lhs: Self, rhs: Self) -> Self {
-        Self::logical(Logical::Or, lhs, rhs)
+    pub fn build_logical_or(lhs: Self, rhs: Self) -> Self {
+        Self::build_logical(Logical::Or, lhs, rhs)
     }
 
-    fn equality(op: Equality, lhs: Self, rhs: Self) -> Self {
+    fn build_equality(op: Equality, lhs: Self, rhs: Self) -> Self {
         Self(spanned!(
             lhs.0.start(),
             ExprKind::Equality(op, Box::new(lhs), Box::new(rhs)),
@@ -391,16 +391,15 @@ impl<'input> Expr<'input> {
         ))
     }
     #[must_use]
-    #[allow(clippy::same_name_method)]
-    pub fn eq(lhs: Self, rhs: Self) -> Self {
-        Self::equality(Equality::Eq, lhs, rhs)
+    pub fn build_eq(lhs: Self, rhs: Self) -> Self {
+        Self::build_equality(Equality::Eq, lhs, rhs)
     }
     #[must_use]
-    pub fn neq(lhs: Self, rhs: Self) -> Self {
-        Self::equality(Equality::Neq, lhs, rhs)
+    pub fn build_neq(lhs: Self, rhs: Self) -> Self {
+        Self::build_equality(Equality::Neq, lhs, rhs)
     }
 
-    fn comparison(op: Comparison, lhs: Self, rhs: Self) -> Self {
+    fn build_comparison(op: Comparison, lhs: Self, rhs: Self) -> Self {
         Self(spanned!(
             lhs.0.start(),
             ExprKind::Comparison(op, Box::new(lhs), Box::new(rhs)),
@@ -408,23 +407,23 @@ impl<'input> Expr<'input> {
         ))
     }
     #[must_use]
-    pub fn gt(lhs: Self, rhs: Self) -> Self {
-        Self::comparison(Comparison::Gt, lhs, rhs)
+    pub fn build_gt(lhs: Self, rhs: Self) -> Self {
+        Self::build_comparison(Comparison::Gt, lhs, rhs)
     }
     #[must_use]
-    pub fn gte(lhs: Self, rhs: Self) -> Self {
-        Self::comparison(Comparison::Gte, lhs, rhs)
+    pub fn build_gte(lhs: Self, rhs: Self) -> Self {
+        Self::build_comparison(Comparison::Gte, lhs, rhs)
     }
     #[must_use]
-    pub fn lt(lhs: Self, rhs: Self) -> Self {
-        Self::comparison(Comparison::Lt, lhs, rhs)
+    pub fn build_lt(lhs: Self, rhs: Self) -> Self {
+        Self::build_comparison(Comparison::Lt, lhs, rhs)
     }
     #[must_use]
-    pub fn lte(lhs: Self, rhs: Self) -> Self {
-        Self::comparison(Comparison::Lte, lhs, rhs)
+    pub fn build_lte(lhs: Self, rhs: Self) -> Self {
+        Self::build_comparison(Comparison::Lte, lhs, rhs)
     }
 
-    fn arithmetic(op: Arithmetic, lhs: Self, rhs: Self) -> Self {
+    fn build_arithmetic(op: Arithmetic, lhs: Self, rhs: Self) -> Self {
         Self(spanned!(
             lhs.0.start(),
             ExprKind::Arithmetic(op, Box::new(lhs), Box::new(rhs)),
@@ -432,55 +431,55 @@ impl<'input> Expr<'input> {
         ))
     }
     #[must_use]
-    pub fn add(lhs: Self, rhs: Self) -> Self {
-        Self::arithmetic(Arithmetic::Addition, lhs, rhs)
+    pub fn build_add(lhs: Self, rhs: Self) -> Self {
+        Self::build_arithmetic(Arithmetic::Addition, lhs, rhs)
     }
     #[must_use]
-    pub fn sub(lhs: Self, rhs: Self) -> Self {
-        Self::arithmetic(Arithmetic::Subtraction, lhs, rhs)
+    pub fn build_sub(lhs: Self, rhs: Self) -> Self {
+        Self::build_arithmetic(Arithmetic::Subtraction, lhs, rhs)
     }
     #[must_use]
-    pub fn mul(lhs: Self, rhs: Self) -> Self {
-        Self::arithmetic(Arithmetic::Multiplication, lhs, rhs)
+    pub fn build_mul(lhs: Self, rhs: Self) -> Self {
+        Self::build_arithmetic(Arithmetic::Multiplication, lhs, rhs)
     }
     #[must_use]
-    pub fn div(lhs: Self, rhs: Self) -> Self {
-        Self::arithmetic(Arithmetic::Division, lhs, rhs)
+    pub fn build_div(lhs: Self, rhs: Self) -> Self {
+        Self::build_arithmetic(Arithmetic::Division, lhs, rhs)
     }
     #[must_use]
-    pub fn modulo(lhs: Self, rhs: Self) -> Self {
-        Self::arithmetic(Arithmetic::Modulo, lhs, rhs)
+    pub fn build_modulo(lhs: Self, rhs: Self) -> Self {
+        Self::build_arithmetic(Arithmetic::Modulo, lhs, rhs)
     }
 
     // Span needed as the unary op may be in a different position than the expr
     #[must_use]
-    pub fn not(sp: Span, expr: Self) -> Self {
+    pub fn build_not(sp: Span, expr: Self) -> Self {
         Self(ExprKind::UnaryNot(Box::new(expr)).in_span(sp))
     }
     #[must_use]
-    pub fn bit_not(sp: Span, expr: Self) -> Self {
+    pub fn build_bit_not(sp: Span, expr: Self) -> Self {
         Self(ExprKind::UnaryBitwiseNot(Box::new(expr)).in_span(sp))
     }
     #[must_use]
-    pub fn neg(sp: Span, expr: Self) -> Self {
+    pub fn build_neg(sp: Span, expr: Self) -> Self {
         Self(ExprKind::UnaryMinus(Box::new(expr)).in_span(sp))
     }
     #[must_use]
-    pub fn address_of(sp: Span, expr: Self) -> Self {
+    pub fn build_address_of(sp: Span, expr: Self) -> Self {
         Self(ExprKind::UnaryAddressOf(Box::new(expr)).in_span(sp))
     }
     #[must_use]
-    pub fn deref(sp: Span, expr: Self) -> Self {
+    pub fn build_deref(sp: Span, expr: Self) -> Self {
         Self(ExprKind::UnaryDereference(Box::new(expr)).in_span(sp))
     }
 
     /// Span is needed for right brace
     #[must_use]
-    pub fn index(sp: Span, lhs: Self, rhs: Self) -> Self {
+    pub fn build_index(sp: Span, lhs: Self, rhs: Self) -> Self {
         Self(ExprKind::Index(Box::new(lhs), Box::new(rhs)).in_span(sp))
     }
     #[must_use]
-    pub fn dot(expr: Self, prop: Spanned<&'input str>) -> Self {
+    pub fn build_dot(expr: Self, prop: Spanned<&'input str>) -> Self {
         Self(spanned!(
             expr.0.start(),
             ExprKind::Dot(Box::new(expr), prop),
@@ -488,21 +487,20 @@ impl<'input> Expr<'input> {
         ))
     }
     #[must_use]
-    pub fn arrow(expr: Self, prop: Spanned<&'input str>) -> Self {
+    pub fn build_arrow(expr: Self, prop: Spanned<&'input str>) -> Self {
         Self(spanned!(
             expr.0.start(),
             ExprKind::Arrow(Box::new(expr), prop),
             prop.end()
         ))
     }
-    // The only nonterminal that needs a span because we can't tell when the ) ends.
-    // We also cannot guess the span of params because it may be empty.
+
     #[must_use]
-    pub fn call(span: Span, f: Self, params: Spanned<Vec<Self>>) -> Self {
+    pub fn build_call(span: Span, f: Self, params: Spanned<Vec<Self>>) -> Self {
         Self(ExprKind::Call(Box::new(f), params).in_span(span))
     }
     #[must_use]
-    pub fn ternary(cond: Self, if_true: Self, if_false: Self) -> Self {
+    pub fn build_ternary(cond: Self, if_true: Self, if_false: Self) -> Self {
         Self(spanned!(
             cond.0.start(),
             ExprKind::Ternary(Box::new(cond), Box::new(if_true), Box::new(if_false)),
@@ -510,7 +508,7 @@ impl<'input> Expr<'input> {
         ))
     }
     #[must_use]
-    pub fn cast(expr: Self, ty: super::ty::Type<'input>) -> Self {
+    pub fn build_cast(expr: Self, ty: super::ty::Type<'input>) -> Self {
         Self(spanned!(
             expr.0.start(),
             ExprKind::Cast(Box::new(expr), ty),
@@ -520,7 +518,7 @@ impl<'input> Expr<'input> {
 
     // These all need spans because they can't be guessed
     #[must_use]
-    pub fn number(lit: Spanned<&'input str>) -> Self {
+    pub fn build_number(lit: Spanned<&'input str>) -> Self {
         let span = lit.span();
         Self(spanned!(
             span.start(),
@@ -529,7 +527,7 @@ impl<'input> Expr<'input> {
         ))
     }
     #[must_use]
-    pub fn string(lit: Spanned<Vec<StringTok<'input>>>) -> Self {
+    pub fn build_string(lit: Spanned<Vec<StringTok<'input>>>) -> Self {
         let span = lit.span();
         Self(spanned!(
             span.start(),
@@ -538,7 +536,7 @@ impl<'input> Expr<'input> {
         ))
     }
     #[must_use]
-    pub fn ident(lit: Spanned<&'input str>) -> Self {
+    pub fn build_ident(lit: Spanned<&'input str>) -> Self {
         let span = lit.span();
         Self(spanned!(
             span.start(),
@@ -547,7 +545,7 @@ impl<'input> Expr<'input> {
         ))
     }
     #[must_use]
-    pub fn bool(lit: Spanned<bool>) -> Self {
+    pub fn build_bool(lit: Spanned<bool>) -> Self {
         let span = lit.span();
         Self(spanned!(
             span.start(),

--- a/compiler/zrc_parser/src/ast/ty.rs
+++ b/compiler/zrc_parser/src/ast/ty.rs
@@ -57,7 +57,7 @@ impl<'input> Display for Type<'input> {
 #[allow(clippy::should_implement_trait)]
 impl<'input> Type<'input> {
     #[must_use]
-    pub fn ident(ident: Spanned<&'input str>) -> Self {
+    pub fn build_ident(ident: Spanned<&'input str>) -> Self {
         let span = ident.span();
         Self(spanned!(
             span.start(),
@@ -68,7 +68,7 @@ impl<'input> Type<'input> {
 
     #[must_use]
     #[allow(clippy::type_complexity)]
-    pub fn struct_direct(
+    pub fn build_struct_from_contents(
         span: Span,
         keys: Spanned<Vec<Spanned<(Spanned<&'input str>, Self)>>>,
     ) -> Self {
@@ -76,7 +76,7 @@ impl<'input> Type<'input> {
     }
 
     #[must_use]
-    pub fn ptr(span: Span, ty: Self) -> Self {
+    pub fn build_ptr(span: Span, ty: Self) -> Self {
         Self(TypeKind::Ptr(Box::new(ty)).in_span(span))
     }
 }

--- a/compiler/zrc_parser/src/parser.rs
+++ b/compiler/zrc_parser/src/parser.rs
@@ -166,20 +166,20 @@ mod tests {
             assert_eq!(
                 // ((1 + 1) - (((1 * 1) / 1) % 1))
                 parse_expr("1 + 1 - 1 * 1 / 1 % 1"),
-                Ok(Expr::sub(
-                    Expr::add(
-                        Expr::number(spanned!(0, "1", 1)),
-                        Expr::number(spanned!(4, "1", 5))
+                Ok(Expr::build_sub(
+                    Expr::build_add(
+                        Expr::build_number(spanned!(0, "1", 1)),
+                        Expr::build_number(spanned!(4, "1", 5))
                     ),
-                    Expr::modulo(
-                        Expr::div(
-                            Expr::mul(
-                                Expr::number(spanned!(8, "1", 9)),
-                                Expr::number(spanned!(12, "1", 13))
+                    Expr::build_modulo(
+                        Expr::build_div(
+                            Expr::build_mul(
+                                Expr::build_number(spanned!(8, "1", 9)),
+                                Expr::build_number(spanned!(12, "1", 13))
                             ),
-                            Expr::number(spanned!(16, "1", 17))
+                            Expr::build_number(spanned!(16, "1", 17))
                         ),
-                        Expr::number(spanned!(20, "1", 21))
+                        Expr::build_number(spanned!(20, "1", 21))
                     )
                 ))
             );
@@ -189,19 +189,19 @@ mod tests {
         fn bitwise_operators_parse_as_expected() {
             assert_eq!(
                 parse_expr("1 & 1 | 1 ^ 1 << 1 >> 1"),
-                Ok(Expr::bit_or(
-                    Expr::bit_and(
-                        Expr::number(spanned!(0, "1", 1)),
-                        Expr::number(spanned!(4, "1", 5))
+                Ok(Expr::build_bit_or(
+                    Expr::build_bit_and(
+                        Expr::build_number(spanned!(0, "1", 1)),
+                        Expr::build_number(spanned!(4, "1", 5))
                     ),
-                    Expr::bit_xor(
-                        Expr::number(spanned!(8, "1", 9)),
-                        Expr::shr(
-                            Expr::shl(
-                                Expr::number(spanned!(12, "1", 13)),
-                                Expr::number(spanned!(17, "1", 18))
+                    Expr::build_bit_xor(
+                        Expr::build_number(spanned!(8, "1", 9)),
+                        Expr::build_shr(
+                            Expr::build_shl(
+                                Expr::build_number(spanned!(12, "1", 13)),
+                                Expr::build_number(spanned!(17, "1", 18))
                             ),
-                            Expr::number(spanned!(22, "1", 23))
+                            Expr::build_number(spanned!(22, "1", 23))
                         )
                     )
                 ))
@@ -212,12 +212,12 @@ mod tests {
         fn logical_operators_parse_as_expected() {
             assert_eq!(
                 parse_expr("1 && 1 || 1"),
-                Ok(Expr::logical_or(
-                    Expr::logical_and(
-                        Expr::number(spanned!(0, "1", 1)),
-                        Expr::number(spanned!(5, "1", 6))
+                Ok(Expr::build_logical_or(
+                    Expr::build_logical_and(
+                        Expr::build_number(spanned!(0, "1", 1)),
+                        Expr::build_number(spanned!(5, "1", 6))
                     ),
-                    Expr::number(spanned!(10, "1", 11))
+                    Expr::build_number(spanned!(10, "1", 11))
                 ))
             );
         }
@@ -226,12 +226,12 @@ mod tests {
         fn equality_operators_parse_as_expected() {
             assert_eq!(
                 parse_expr("1 == 1 != 1"),
-                Ok(Expr::neq(
-                    Expr::eq(
-                        Expr::number(spanned!(0, "1", 1)),
-                        Expr::number(spanned!(5, "1", 6))
+                Ok(Expr::build_neq(
+                    Expr::build_eq(
+                        Expr::build_number(spanned!(0, "1", 1)),
+                        Expr::build_number(spanned!(5, "1", 6))
                     ),
-                    Expr::number(spanned!(10, "1", 11))
+                    Expr::build_number(spanned!(10, "1", 11))
                 ))
             );
         }
@@ -240,18 +240,18 @@ mod tests {
         fn comparison_operators_parse_as_expected() {
             assert_eq!(
                 parse_expr("1 > 1 >= 1 < 1 <= 1"),
-                Ok(Expr::lte(
-                    Expr::lt(
-                        Expr::gte(
-                            Expr::gt(
-                                Expr::number(spanned!(0, "1", 1)),
-                                Expr::number(spanned!(4, "1", 5))
+                Ok(Expr::build_lte(
+                    Expr::build_lt(
+                        Expr::build_gte(
+                            Expr::build_gt(
+                                Expr::build_number(spanned!(0, "1", 1)),
+                                Expr::build_number(spanned!(4, "1", 5))
                             ),
-                            Expr::number(spanned!(9, "1", 10))
+                            Expr::build_number(spanned!(9, "1", 10))
                         ),
-                        Expr::number(spanned!(13, "1", 14))
+                        Expr::build_number(spanned!(13, "1", 14))
                     ),
-                    Expr::number(spanned!(18, "1", 19))
+                    Expr::build_number(spanned!(18, "1", 19))
                 ))
             );
         }
@@ -260,17 +260,17 @@ mod tests {
         fn unary_operators_parse_as_expected() {
             assert_eq!(
                 parse_expr("!~-&*x"),
-                Ok(Expr::not(
+                Ok(Expr::build_not(
                     Span::from_positions(0, 6),
-                    Expr::bit_not(
+                    Expr::build_bit_not(
                         Span::from_positions(1, 6),
-                        Expr::neg(
+                        Expr::build_neg(
                             Span::from_positions(2, 6),
-                            Expr::address_of(
+                            Expr::build_address_of(
                                 Span::from_positions(3, 6),
-                                Expr::deref(
+                                Expr::build_deref(
                                     Span::from_positions(4, 6),
-                                    Expr::ident(spanned!(5, "x", 6))
+                                    Expr::build_ident(spanned!(5, "x", 6))
                                 )
                             )
                         )
@@ -283,12 +283,12 @@ mod tests {
         fn indexing_operators_parse_as_expected() {
             assert_eq!(
                 parse_expr("x[x].x->x"),
-                Ok(Expr::arrow(
-                    Expr::dot(
-                        Expr::index(
+                Ok(Expr::build_arrow(
+                    Expr::build_dot(
+                        Expr::build_index(
                             Span::from_positions(0, 4),
-                            Expr::ident(spanned!(0, "x", 1)),
-                            Expr::ident(spanned!(2, "x", 3))
+                            Expr::build_ident(spanned!(0, "x", 1)),
+                            Expr::build_ident(spanned!(2, "x", 3))
                         ),
                         spanned!(5, "x", 6)
                     ),
@@ -301,14 +301,14 @@ mod tests {
         fn function_calls_parse_as_expected() {
             assert_eq!(
                 parse_expr("f(x, y)"),
-                Ok(Expr::call(
+                Ok(Expr::build_call(
                     Span::from_positions(0, 7),
-                    Expr::ident(spanned!(0, "f", 1)),
+                    Expr::build_ident(spanned!(0, "f", 1)),
                     spanned!(
                         1,
                         vec![
-                            Expr::ident(spanned!(2, "x", 3)),
-                            Expr::ident(spanned!(5, "y", 6))
+                            Expr::build_ident(spanned!(2, "x", 3)),
+                            Expr::build_ident(spanned!(5, "y", 6))
                         ],
                         7
                     )
@@ -320,10 +320,10 @@ mod tests {
         fn ternary_operator_parses_as_expected() {
             assert_eq!(
                 parse_expr("a ? b : c"),
-                Ok(Expr::ternary(
-                    Expr::ident(spanned!(0, "a", 1)),
-                    Expr::ident(spanned!(4, "b", 5)),
-                    Expr::ident(spanned!(8, "c", 9))
+                Ok(Expr::build_ternary(
+                    Expr::build_ident(spanned!(0, "a", 1)),
+                    Expr::build_ident(spanned!(4, "b", 5)),
+                    Expr::build_ident(spanned!(8, "c", 9))
                 ))
             );
         }
@@ -332,9 +332,9 @@ mod tests {
         fn casts_parse_as_expected() {
             assert_eq!(
                 parse_expr("x as T"),
-                Ok(Expr::cast(
-                    Expr::ident(spanned!(0, "x", 1)),
-                    Type::ident(spanned!(5, "T", 6))
+                Ok(Expr::build_cast(
+                    Expr::build_ident(spanned!(0, "x", 1)),
+                    Type::build_ident(spanned!(5, "T", 6))
                 ))
             );
         }
@@ -345,25 +345,32 @@ mod tests {
 
             #[test]
             fn number_literals_parse_as_expected() {
-                assert_eq!(parse_expr("1"), Ok(Expr::number(spanned!(0, "1", 1))));
+                assert_eq!(parse_expr("1"), Ok(Expr::build_number(spanned!(0, "1", 1))));
             }
 
             #[test]
             fn string_literals_parse_as_expected() {
                 assert_eq!(
                     parse_expr("\"x\""),
-                    Ok(Expr::string(spanned!(0, vec![StringTok::Text("x")], 3)))
+                    Ok(Expr::build_string(spanned!(
+                        0,
+                        vec![StringTok::Text("x")],
+                        3
+                    )))
                 );
             }
 
             #[test]
             fn identifiers_parse_as_expected() {
-                assert_eq!(parse_expr("x"), Ok(Expr::ident(spanned!(0, "x", 1))));
+                assert_eq!(parse_expr("x"), Ok(Expr::build_ident(spanned!(0, "x", 1))));
             }
 
             #[test]
             fn booleans_parse_as_expected() {
-                assert_eq!(parse_expr("true"), Ok(Expr::bool(spanned!(0, true, 4))));
+                assert_eq!(
+                    parse_expr("true"),
+                    Ok(Expr::build_bool(spanned!(0, true, 4)))
+                );
             }
         }
     }

--- a/compiler/zrc_typeck/src/typeck/expr.rs
+++ b/compiler/zrc_typeck/src/typeck/expr.rs
@@ -639,12 +639,12 @@ mod tests {
                 // a = b
                 desugar_assignment(
                     Assignment::Standard,
-                    Expr::ident(spanned!(0, "a", 1)),
-                    Expr::ident(spanned!(4, "b", 5)),
+                    Expr::build_ident(spanned!(0, "a", 1)),
+                    Expr::build_ident(spanned!(4, "b", 5)),
                 ),
                 (
-                    Expr::ident(spanned!(0, "a", 1)),
-                    Expr::ident(spanned!(4, "b", 5)),
+                    Expr::build_ident(spanned!(0, "a", 1)),
+                    Expr::build_ident(spanned!(4, "b", 5)),
                 )
             );
         }
@@ -655,18 +655,18 @@ mod tests {
                 // a += b
                 desugar_assignment(
                     Assignment::Arithmetic(Arithmetic::Addition),
-                    Expr::ident(spanned!(0, "a", 1)),
-                    Expr::ident(spanned!(5, "b", 6)),
+                    Expr::build_ident(spanned!(0, "a", 1)),
+                    Expr::build_ident(spanned!(5, "b", 6)),
                 ),
                 (
-                    Expr::ident(spanned!(0, "a", 1)),
+                    Expr::build_ident(spanned!(0, "a", 1)),
                     // An exception to the normal spanning rules applies here
                     Expr(spanned!(
                         5,
                         ExprKind::Arithmetic(
                             Arithmetic::Addition,
-                            Box::new(Expr::ident(spanned!(0, "a", 1))),
-                            Box::new(Expr::ident(spanned!(5, "b", 6)))
+                            Box::new(Expr::build_ident(spanned!(0, "a", 1))),
+                            Box::new(Expr::build_ident(spanned!(5, "b", 6)))
                         ),
                         6
                     ))
@@ -680,18 +680,18 @@ mod tests {
                 // a >>= b
                 desugar_assignment(
                     Assignment::BinaryBitwise(BinaryBitwise::Shr),
-                    Expr::ident(spanned!(0, "a", 1)),
-                    Expr::ident(spanned!(6, "b", 7)),
+                    Expr::build_ident(spanned!(0, "a", 1)),
+                    Expr::build_ident(spanned!(6, "b", 7)),
                 ),
                 (
-                    Expr::ident(spanned!(0, "a", 1)),
+                    Expr::build_ident(spanned!(0, "a", 1)),
                     // An exception to the normal spanning rules applies here
                     Expr(spanned!(
                         6,
                         ExprKind::BinaryBitwise(
                             BinaryBitwise::Shr,
-                            Box::new(Expr::ident(spanned!(0, "a", 1))),
-                            Box::new(Expr::ident(spanned!(6, "b", 7)))
+                            Box::new(Expr::build_ident(spanned!(0, "a", 1))),
+                            Box::new(Expr::build_ident(spanned!(6, "b", 7)))
                         ),
                         7
                     ))

--- a/compiler/zrc_typeck/src/typeck/expr.rs
+++ b/compiler/zrc_typeck/src/typeck/expr.rs
@@ -639,12 +639,12 @@ mod tests {
                 // a = b
                 desugar_assignment(
                     Assignment::Standard,
-                    Expr(spanned!(0, ExprKind::Identifier("a"), 1)),
-                    Expr(spanned!(4, ExprKind::Identifier("b"), 5))
+                    Expr::ident(spanned!(0, "a", 1)),
+                    Expr::ident(spanned!(4, "b", 5)),
                 ),
                 (
-                    Expr(spanned!(0, ExprKind::Identifier("a"), 1)),
-                    Expr(spanned!(4, ExprKind::Identifier("b"), 5))
+                    Expr::ident(spanned!(0, "a", 1)),
+                    Expr::ident(spanned!(4, "b", 5)),
                 )
             );
         }
@@ -655,17 +655,18 @@ mod tests {
                 // a += b
                 desugar_assignment(
                     Assignment::Arithmetic(Arithmetic::Addition),
-                    Expr(spanned!(0, ExprKind::Identifier("a"), 1)),
-                    Expr(spanned!(5, ExprKind::Identifier("b"), 6))
+                    Expr::ident(spanned!(0, "a", 1)),
+                    Expr::ident(spanned!(5, "b", 6)),
                 ),
                 (
-                    Expr(spanned!(0, ExprKind::Identifier("a"), 1)),
+                    Expr::ident(spanned!(0, "a", 1)),
+                    // An exception to the normal spanning rules applies here
                     Expr(spanned!(
                         5,
                         ExprKind::Arithmetic(
                             Arithmetic::Addition,
-                            Box::new(Expr(spanned!(0, ExprKind::Identifier("a"), 1))),
-                            Box::new(Expr(spanned!(5, ExprKind::Identifier("b"), 6)))
+                            Box::new(Expr::ident(spanned!(0, "a", 1))),
+                            Box::new(Expr::ident(spanned!(5, "b", 6)))
                         ),
                         6
                     ))
@@ -679,17 +680,18 @@ mod tests {
                 // a >>= b
                 desugar_assignment(
                     Assignment::BinaryBitwise(BinaryBitwise::Shr),
-                    Expr(spanned!(0, ExprKind::Identifier("a"), 1)),
-                    Expr(spanned!(6, ExprKind::Identifier("b"), 7))
+                    Expr::ident(spanned!(0, "a", 1)),
+                    Expr::ident(spanned!(6, "b", 7)),
                 ),
                 (
-                    Expr(spanned!(0, ExprKind::Identifier("a"), 1)),
+                    Expr::ident(spanned!(0, "a", 1)),
+                    // An exception to the normal spanning rules applies here
                     Expr(spanned!(
                         6,
                         ExprKind::BinaryBitwise(
                             BinaryBitwise::Shr,
-                            Box::new(Expr(spanned!(0, ExprKind::Identifier("a"), 1))),
-                            Box::new(Expr(spanned!(6, ExprKind::Identifier("b"), 7)))
+                            Box::new(Expr::ident(spanned!(0, "a", 1))),
+                            Box::new(Expr::ident(spanned!(6, "b", 7)))
                         ),
                         7
                     ))

--- a/compiler/zrc_typeck/src/typeck/ty.rs
+++ b/compiler/zrc_typeck/src/typeck/ty.rs
@@ -69,7 +69,7 @@ pub(super) fn resolve_struct_keys<'input>(
 mod tests {
     use std::collections::HashMap;
 
-    use zrc_utils::spanned;
+    use zrc_utils::{span::Span, spanned};
 
     use super::*;
 
@@ -78,15 +78,10 @@ mod tests {
         assert_eq!(
             resolve_type(
                 &Scope::from_scopes(HashMap::new(), HashMap::from([("i32", TastType::I32)])),
-                ParserType(spanned!(
-                    0,
-                    ParserTypeKind::Ptr(Box::new(ParserType(spanned!(
-                        1,
-                        ParserTypeKind::Identifier("i32"),
-                        4
-                    )))),
-                    4
-                ))
+                ParserType::ptr(
+                    Span::from_positions(0, 4),
+                    ParserType::ident(spanned!(1, "i32", 4)),
+                ),
             ),
             Ok(TastType::Ptr(Box::new(TastType::I32)))
         );
@@ -95,10 +90,7 @@ mod tests {
     #[test]
     fn invalid_types_produce_error() {
         assert_eq!(
-            resolve_type(
-                &Scope::new(),
-                ParserType(spanned!(0, ParserTypeKind::Identifier("x"), 1))
-            ),
+            resolve_type(&Scope::new(), ParserType::ident(spanned!(0, "x", 1))),
             Err(Diagnostic(
                 Severity::Error,
                 spanned!(0, DiagnosticKind::UnableToResolveType("x".to_string()), 1)
@@ -152,9 +144,9 @@ mod tests {
         assert_eq!(
             resolve_type(
                 &Scope::default(),
-                ParserType(spanned!(
-                    0,
-                    ParserTypeKind::Struct(spanned!(
+                ParserType::struct_direct(
+                    Span::from_positions(0, 25),
+                    spanned!(
                         7,
                         vec![
                             spanned!(
@@ -175,9 +167,8 @@ mod tests {
                             )
                         ],
                         25
-                    )),
-                    25
-                ))
+                    ),
+                )
             ),
             Err(Diagnostic(
                 Severity::Error,

--- a/compiler/zrc_typeck/src/typeck/ty.rs
+++ b/compiler/zrc_typeck/src/typeck/ty.rs
@@ -78,9 +78,9 @@ mod tests {
         assert_eq!(
             resolve_type(
                 &Scope::from_scopes(HashMap::new(), HashMap::from([("i32", TastType::I32)])),
-                ParserType::ptr(
+                ParserType::build_ptr(
                     Span::from_positions(0, 4),
-                    ParserType::ident(spanned!(1, "i32", 4)),
+                    ParserType::build_ident(spanned!(1, "i32", 4)),
                 ),
             ),
             Ok(TastType::Ptr(Box::new(TastType::I32)))
@@ -90,7 +90,7 @@ mod tests {
     #[test]
     fn invalid_types_produce_error() {
         assert_eq!(
-            resolve_type(&Scope::new(), ParserType::ident(spanned!(0, "x", 1))),
+            resolve_type(&Scope::new(), ParserType::build_ident(spanned!(0, "x", 1))),
             Err(Diagnostic(
                 Severity::Error,
                 spanned!(0, DiagnosticKind::UnableToResolveType("x".to_string()), 1)
@@ -144,7 +144,7 @@ mod tests {
         assert_eq!(
             resolve_type(
                 &Scope::default(),
-                ParserType::struct_direct(
+                ParserType::build_struct_from_contents(
                     Span::from_positions(0, 25),
                     spanned!(
                         7,


### PR DESCRIPTION
stacked, so depends #105