### PR TITLE
feat(typeck): prevent declaring a variable with type `void`

### DIFF
--- a/compiler/zrc_diagnostics/src/lib.rs
+++ b/compiler/zrc_diagnostics/src/lib.rs
@@ -156,6 +156,7 @@ pub enum DiagnosticKind {
     ExpectedABlockToReturn,
     DuplicateStructMember(String),
     VariadicFunctionMustBeExternal,
+    CannotDeclareVoid,
 }
 
 impl Display for DiagnosticKind {
@@ -281,6 +282,10 @@ impl Display for DiagnosticKind {
             Self::JavascriptUserDetected => {
                 write!(f, "JavaScript user detected -- did you mean `==`?")
             }
+            Self::CannotDeclareVoid => write!(
+                f,
+                "cannot declare a variable of type `void` -- just discard the value"
+            ),
         }
     }
 }

--- a/compiler/zrc_typeck/src/typeck/block.rs
+++ b/compiler/zrc_typeck/src/typeck/block.rs
@@ -195,6 +195,16 @@ fn process_let_declaration<'input>(
                         }
                     }
                 };
+
+                if result_decl.ty == TastType::Void {
+                    return Err(Diagnostic(
+                        Severity::Error,
+                        let_declaration
+                            .span()
+                            .containing(DiagnosticKind::CannotDeclareVoid),
+                    ));
+                }
+
                 scope.set_value(result_decl.name, result_decl.ty.clone());
                 Ok(result_decl)
             },


### PR DESCRIPTION
This creates the following diagnostic to prevent the ICE in #40:
```
error: cannot declare a variable of type `void` -- just discard the value
 3 |     let x = void();
   |         ^^^^^^^^^^
```

Fixes #40