### PR TITLE
refactor(tast): do not include EmptyStmt and type declarations in TAST

### DIFF
--- a/compiler/zrc_codegen/src/stmt.rs
+++ b/compiler/zrc_codegen/src/stmt.rs
@@ -120,7 +120,6 @@ fn cg_block<'ctx, 'input, 'a>(
         .into_iter()
         .try_fold(*bb, |bb, stmt| -> Option<BasicBlock> {
             match stmt {
-                TypedStmt::EmptyStmt => Some(bb),
                 TypedStmt::ExprStmt(expr) => Some(
                     cg_expr(
                         ctx,
@@ -494,9 +493,6 @@ fn cg_program<'input, 'ctx>(
 
     for declaration in program {
         match declaration {
-            // Struct and union declarations do not need to be emitted
-            TypedDeclaration::TypeAliasDeclaration { .. } => {}
-
             TypedDeclaration::FunctionDeclaration {
                 name,
                 parameters,

--- a/compiler/zrc_typeck/src/tast/stmt.rs
+++ b/compiler/zrc_typeck/src/tast/stmt.rs
@@ -57,8 +57,6 @@ pub enum TypedStmt<'input> {
     BlockStmt(Vec<TypedStmt<'input>>),
     /// `x;`
     ExprStmt(TypedExpr<'input>),
-    /// `;`
-    EmptyStmt,
     /// `continue;`
     ContinueStmt,
     /// `break;`
@@ -84,13 +82,6 @@ pub enum TypedDeclaration<'input> {
         /// The body of the function. If set to [`None`], this is an extern
         /// declaration.
         body: Option<Vec<TypedStmt<'input>>>,
-    },
-    /// A named type alias (`type U = T;`)
-    TypeAliasDeclaration {
-        /// The name of the newtype.
-        name: &'input str,
-        /// The type to associate.
-        ty: Type<'input>,
     },
 }
 
@@ -199,7 +190,6 @@ impl<'input> Display for TypedDeclaration<'input> {
                 return_type: None,
                 body: None,
             } => write!(f, "fn {name}({parameters});"),
-            Self::TypeAliasDeclaration { name, ty } => write!(f, "type {name} = {ty};"),
         }
     }
 }
@@ -301,7 +291,6 @@ impl<'input> Display for TypedStmt<'input> {
                     .join("\n")
             ),
             Self::ExprStmt(expr) => write!(f, "{expr};"),
-            Self::EmptyStmt => write!(f, ";"),
             Self::ContinueStmt => write!(f, "continue;"),
             Self::BreakStmt => write!(f, "break;"),
             Self::ReturnStmt(Some(expr)) => write!(f, "return {expr};",),

--- a/compiler/zrc_typeck/src/typeck.rs
+++ b/compiler/zrc_typeck/src/typeck.rs
@@ -107,6 +107,8 @@ pub fn type_program(
 
     program
         .into_iter()
-        .map(|declaration| process_declaration(&mut scope, declaration.into_value()))
+        .filter_map(|declaration| {
+            process_declaration(&mut scope, declaration.into_value()).transpose()
+        })
         .collect()
 }


### PR DESCRIPTION
fixes #109