### PR TITLE
feat(lang): add character literals

### DIFF
--- a/compiler/zrc_parser/src/ast/expr.rs
+++ b/compiler/zrc_parser/src/ast/expr.rs
@@ -241,6 +241,8 @@ pub enum ExprKind<'input> {
     NumberLiteral(&'input str),
     /// Any string literal.
     StringLiteral(Vec<StringTok<'input>>),
+    /// Any char literal
+    CharLiteral(Vec<StringTok<'input>>),
     /// Any identifier.
     Identifier(&'input str),
     /// Any boolean literal.
@@ -254,6 +256,11 @@ impl<'input> Display for ExprKind<'input> {
             Self::StringLiteral(str) => write!(
                 f,
                 "\"{}\"",
+                str.iter().map(ToString::to_string).collect::<String>()
+            ),
+            Self::CharLiteral(str) => write!(
+                f,
+                "'{}'",
                 str.iter().map(ToString::to_string).collect::<String>()
             ),
             Self::Identifier(i) => write!(f, "{i}"),
@@ -540,6 +547,15 @@ impl<'input> Expr<'input> {
         Self(spanned!(
             span.start(),
             ExprKind::StringLiteral(lit.into_value()),
+            span.end()
+        ))
+    }
+    #[must_use]
+    pub fn build_char(lit: Spanned<Vec<StringTok<'input>>>) -> Self {
+        let span = lit.span();
+        Self(spanned!(
+            span.start(),
+            ExprKind::CharLiteral(lit.into_value()),
             span.end()
         ))
     }

--- a/compiler/zrc_parser/src/internal_parser.lalrpop
+++ b/compiler/zrc_parser/src/internal_parser.lalrpop
@@ -316,6 +316,7 @@ ArgumentList: Vec<Expr<'input>> = CommaSeparated<Assignment>;
 Primary: Expr<'input> = {
     Spanned<NUMBER> => Expr(<>.map(|n| ExprKind::NumberLiteral(n))),
     Spanned<STRING> => Expr(<>.map(|s| ExprKind::StringLiteral(s))),
+    Spanned<CHAR> => Expr(<>.map(|c| ExprKind::CharLiteral(c))),
     Spanned<IDENTIFIER> => Expr(<>.map(|i| ExprKind::Identifier(i))),
     Spanned<"true"> => Expr(<>.map(|_| ExprKind::BooleanLiteral(true))),
     Spanned<"false"> => Expr(<>.map(|_| ExprKind::BooleanLiteral(false))),
@@ -378,6 +379,7 @@ extern {
         "]" => lexer::Tok::RightBracket,
 
         STRING => lexer::Tok::StringLiteral(<Vec<lexer::StringTok<'input>>>),
+        CHAR => lexer::Tok::CharLiteral(<Vec<lexer::StringTok<'input>>>),
         NUMBER => lexer::Tok::NumberLiteral(<&'input str>),
         IDENTIFIER => lexer::Tok::Identifier(<&'input str>),
 

--- a/compiler/zrc_parser/src/lexer.rs
+++ b/compiler/zrc_parser/src/lexer.rs
@@ -403,6 +403,12 @@ pub enum Tok<'input> {
     Ellipsis,
 
     // === SPECIAL ===
+    /// Any character literal
+    #[regex(r"'([^'\\]|\\.)*'", lex_string_contents)]
+    #[regex(r"'([^'\\]|\\.)*", |_lex| {
+        Err(InternalLexicalError::UnterminatedStringLiteral)
+    })]
+    CharLiteral(Vec<StringTok<'input>>),
     /// Any string literal
     #[regex(r#""([^"\\]|\\.)*""#, lex_string_contents)]
     #[regex(r#""([^"\\]|\\.)*"#, |_lex| {
@@ -467,6 +473,10 @@ impl<'input> Display for Tok<'input> {
                 Self::StringLiteral(str) => format!(
                     "\"{}\"",
                     str.iter().map(ToString::to_string).collect::<String>()
+                ),
+                Self::CharLiteral(ch) => format!(
+                    "'{}'",
+                    ch.iter().map(ToString::to_string).collect::<String>()
                 ),
                 Self::Struct => "struct".to_string(),
                 Self::Union => "union".to_string(),

--- a/compiler/zrc_typeck/src/tast/expr.rs
+++ b/compiler/zrc_typeck/src/tast/expr.rs
@@ -95,6 +95,8 @@ pub enum TypedExprKind<'input> {
     NumberLiteral(&'input str),
     /// Any string literal.bool
     StringLiteral(Vec<StringTok<'input>>),
+    /// Any char literal
+    CharLiteral(Vec<StringTok<'input>>),
     /// Any identifier.
     Identifier(&'input str),
     /// Any boolean literal.
@@ -108,6 +110,11 @@ impl<'input> Display for TypedExprKind<'input> {
             Self::StringLiteral(str) => write!(
                 f,
                 "\"{}\"",
+                str.iter().map(ToString::to_string).collect::<String>()
+            ),
+            Self::CharLiteral(str) => write!(
+                f,
+                "\'{}\'",
                 str.iter().map(ToString::to_string).collect::<String>()
             ),
             Self::Identifier(i) => write!(f, "{i}"),

--- a/compiler/zrc_typeck/src/typeck/expr.rs
+++ b/compiler/zrc_typeck/src/typeck/expr.rs
@@ -612,6 +612,7 @@ pub fn type_expr<'input>(
             TastType::Ptr(Box::new(TastType::U8)),
             TypedExprKind::StringLiteral(str),
         ),
+        ExprKind::CharLiteral(ch) => TypedExpr(TastType::U8, TypedExprKind::CharLiteral(ch)),
         ExprKind::Identifier(i) => {
             let ty = scope.get_value(i).ok_or_else(|| {
                 Diagnostic(


### PR DESCRIPTION
Adds character literals like `'a'` to the language.
