### PR TITLE
feat: add debuginfo to tast

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1249,6 +1249,7 @@ dependencies = [
  "indexmap",
  "inkwell",
  "zrc_typeck",
+ "zrc_utils",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -552,6 +552,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "line-col"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e69cdf6b85b5c8dce514f694089a2cf8b1a702f6cd28607bcb3cf296c9778db"
+
+[[package]]
 name = "line-span"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1248,6 +1254,7 @@ version = "0.1.0"
 dependencies = [
  "indexmap",
  "inkwell",
+ "line-col",
  "zrc_typeck",
  "zrc_utils",
 ]

--- a/compiler/zrc_codegen/Cargo.toml
+++ b/compiler/zrc_codegen/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dependencies]
 inkwell = { git = "https://github.com/TheDan64/inkwell", version = "0.2.0", features = ["llvm16-0", "llvm16-0-prefer-static"] }
+line-col = "0.2.1"
 zrc_typeck = { version = "0.1.0", path = "../zrc_typeck" }
 zrc_utils = { version = "0.1.0", path = "../zrc_utils" }
 

--- a/compiler/zrc_codegen/Cargo.toml
+++ b/compiler/zrc_codegen/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 inkwell = { git = "https://github.com/TheDan64/inkwell", version = "0.2.0", features = ["llvm16-0", "llvm16-0-prefer-static"] }
 zrc_typeck = { version = "0.1.0", path = "../zrc_typeck" }
+zrc_utils = { version = "0.1.0", path = "../zrc_utils" }
 
 [dev-dependencies]
 indexmap = "2.1.0"

--- a/compiler/zrc_codegen/src/lib.rs
+++ b/compiler/zrc_codegen/src/lib.rs
@@ -63,6 +63,7 @@ pub use inkwell::{
     targets::{FileType, TargetTriple},
     OptimizationLevel,
 };
+use line_col::LineColLookup;
 pub use stmt::{cg_program_to_buffer, cg_program_to_string};
 
 /// Gets the native [`TargetTriple`].
@@ -101,4 +102,26 @@ impl<'input, 'ctx> Default for CgScope<'input, 'ctx> {
     fn default() -> Self {
         Self::new()
     }
+}
+
+pub struct LineLookup<'a> {
+    inner: LineColLookup<'a>,
+}
+impl<'a> LineLookup<'a> {
+    pub fn new(str: &'a str) -> Self {
+        Self {
+            inner: LineColLookup::new(str),
+        }
+    }
+
+    pub fn get_line_and_column(&self, index: usize) -> LineAndColumn {
+        let (line, col) = self.inner.get(index);
+        // LLVM says line numbers start at 1
+        LineAndColumn { line, col }
+    }
+}
+
+pub struct LineAndColumn {
+    pub line: usize,
+    pub col: usize,
 }

--- a/compiler/zrc_codegen/src/ty.rs
+++ b/compiler/zrc_codegen/src/ty.rs
@@ -2,6 +2,7 @@
 
 use inkwell::{
     context::Context,
+    debug_info::{DIBasicType, DebugInfoBuilder},
     targets::TargetMachine,
     types::{
         AnyType, AnyTypeEnum, BasicMetadataTypeEnum, BasicType, BasicTypeEnum, FunctionType,
@@ -10,6 +11,14 @@ use inkwell::{
     AddressSpace,
 };
 use zrc_typeck::tast::ty::Type;
+
+/// Create the LLVM [`DIBasicType`] for a [`Type`] node.
+// TODO: Properly create the composite types etc.
+pub fn create_di_type<'ctx>(dbg_builder: &DebugInfoBuilder<'ctx>, ty: &Type) -> DIBasicType<'ctx> {
+    dbg_builder
+        .create_basic_type(&ty.to_string(), 0, 0, 0)
+        .unwrap()
+}
 
 /// Create a pointer to an [`AnyTypeEnum`] instance.
 ///

--- a/compiler/zrc_typeck/src/tast.rs
+++ b/compiler/zrc_typeck/src/tast.rs
@@ -2,6 +2,9 @@
 //!
 //! This is similar to the [standard AST](zrc_parser::ast), but with type
 //! information attached to it.
+//!
+//! Note that we only attach source locations to code that would exist after code generation,
+//! meaning inlined types do not get a span.
 
 pub mod expr;
 pub mod stmt;

--- a/compiler/zrc_typeck/src/tast/stmt.rs
+++ b/compiler/zrc_typeck/src/tast/stmt.rs
@@ -42,11 +42,11 @@ pub enum TypedStmtKind<'input> {
     /// `if (x) y` or `if (x) y else z`
     IfStmt(
         TypedExpr<'input>,
-        Vec<TypedStmt<'input>>,
-        Option<Vec<TypedStmt<'input>>>,
+        Spanned<Vec<TypedStmt<'input>>>,
+        Option<Spanned<Vec<TypedStmt<'input>>>>,
     ),
     /// `while (x) y`
-    WhileStmt(TypedExpr<'input>, Vec<TypedStmt<'input>>),
+    WhileStmt(TypedExpr<'input>, Spanned<Vec<TypedStmt<'input>>>),
     /// `for (init; cond; post) body`
     ForStmt {
         /// Runs once before the loop starts.
@@ -58,7 +58,7 @@ pub enum TypedStmtKind<'input> {
         /// Runs after each iteration of the loop.
         post: Option<TypedExpr<'input>>,
         /// The body of the loop.
-        body: Vec<TypedStmt<'input>>,
+        body: Spanned<Vec<TypedStmt<'input>>>,
     },
     /// `{ ... }`
     BlockStmt(Vec<TypedStmt<'input>>),
@@ -213,6 +213,7 @@ impl<'input> Display for TypedStmtKind<'input> {
                 f,
                 "if ({cond}) {{\n{}\n}} else {{\n{}\n}}",
                 if_true
+                    .value()
                     .iter()
                     .map(|stmt| stmt
                         .0
@@ -225,6 +226,7 @@ impl<'input> Display for TypedStmtKind<'input> {
                     .collect::<Vec<_>>()
                     .join("\n"),
                 if_false
+                    .value()
                     .iter()
                     .map(|stmt| stmt
                         .0
@@ -241,6 +243,7 @@ impl<'input> Display for TypedStmtKind<'input> {
                 f,
                 "if ({cond}) {{\n{}\n}}",
                 if_true
+                    .value()
                     .iter()
                     .map(|stmt| stmt
                         .0
@@ -256,7 +259,8 @@ impl<'input> Display for TypedStmtKind<'input> {
             Self::WhileStmt(cond, body) => write!(
                 f,
                 "while ({cond}) {{\n{}\n}}",
-                body.iter()
+                body.value()
+                    .iter()
                     .map(|stmt| stmt
                         .0
                         .value()
@@ -285,7 +289,8 @@ impl<'input> Display for TypedStmtKind<'input> {
                 )),
                 cond.clone().map_or(String::new(), |x| x.to_string()),
                 post.clone().map_or(String::new(), |x| x.to_string()),
-                body.iter()
+                body.value()
+                    .iter()
                     .map(|stmt| stmt
                         .0
                         .value()

--- a/compiler/zrc_typeck/src/tast/stmt.rs
+++ b/compiler/zrc_typeck/src/tast/stmt.rs
@@ -2,13 +2,15 @@
 
 use std::{fmt::Display, string::ToString};
 
+use zrc_utils::span::Spanned;
+
 use super::{expr::TypedExpr, ty::Type};
 
 /// A declaration created with `let`.
 #[derive(Debug, Clone, PartialEq)]
 pub struct LetDeclaration<'input> {
     /// The name of the identifier.
-    pub name: &'input str,
+    pub name: Spanned<&'input str>,
     /// The type of the new symbol. If set to [`None`], the type will be
     /// inferred.
     pub ty: Type<'input>, // types are definite after inference
@@ -19,17 +21,22 @@ pub struct LetDeclaration<'input> {
 impl<'input> Display for LetDeclaration<'input> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match &self.value {
-            Some(value) => write!(f, "{}: {} = {}", self.name, self.ty, value),
-            None => write!(f, "{}: {}", self.name, self.ty),
+            Some(value) => write!(f, "{}: {} = {}", self.name.value(), self.ty, value),
+            None => write!(f, "{}: {}", self.name.value(), self.ty),
         }
     }
 }
+
+/// A typed statement with a span
+#[derive(PartialEq, Debug, Clone)]
+#[allow(clippy::module_name_repetitions)]
+pub struct TypedStmt<'input>(pub Spanned<TypedStmtKind<'input>>);
 
 /// The enum representing all of the different kinds of statements in Zirco
 /// after type checking
 #[derive(Debug, Clone, PartialEq)]
 #[allow(clippy::module_name_repetitions)]
-pub enum TypedStmt<'input> {
+pub enum TypedStmtKind<'input> {
     // all of the Box<Stmt>s for "possibly blocks" have been desugared into vec[single stmt] here
     // (basically if (x) y has become if (x) {y})
     /// `if (x) y` or `if (x) y else z`
@@ -152,6 +159,8 @@ impl<'input> Display for TypedDeclaration<'input> {
                 parameters,
                 body.iter()
                     .map(|stmt| stmt
+                        .0
+                        .value()
                         .to_string()
                         .split('\n')
                         .map(|x| format!("    {x}"))
@@ -176,6 +185,8 @@ impl<'input> Display for TypedDeclaration<'input> {
                 "fn {name}({parameters}) {{\n{}\n}}",
                 body.iter()
                     .map(|stmt| stmt
+                        .0
+                        .value()
                         .to_string()
                         .split('\n')
                         .map(|x| format!("    {x}"))
@@ -194,7 +205,7 @@ impl<'input> Display for TypedDeclaration<'input> {
     }
 }
 
-impl<'input> Display for TypedStmt<'input> {
+impl<'input> Display for TypedStmtKind<'input> {
     #[allow(clippy::too_many_lines)]
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -204,6 +215,8 @@ impl<'input> Display for TypedStmt<'input> {
                 if_true
                     .iter()
                     .map(|stmt| stmt
+                        .0
+                        .value()
                         .to_string()
                         .split('\n')
                         .map(|x| format!("    {x}"))
@@ -214,6 +227,8 @@ impl<'input> Display for TypedStmt<'input> {
                 if_false
                     .iter()
                     .map(|stmt| stmt
+                        .0
+                        .value()
                         .to_string()
                         .split('\n')
                         .map(|x| format!("    {x}"))
@@ -228,6 +243,8 @@ impl<'input> Display for TypedStmt<'input> {
                 if_true
                     .iter()
                     .map(|stmt| stmt
+                        .0
+                        .value()
                         .to_string()
                         .split('\n')
                         .map(|x| format!("    {x}"))
@@ -241,6 +258,8 @@ impl<'input> Display for TypedStmt<'input> {
                 "while ({cond}) {{\n{}\n}}",
                 body.iter()
                     .map(|stmt| stmt
+                        .0
+                        .value()
                         .to_string()
                         .split('\n')
                         .map(|x| format!("    {x}"))
@@ -268,6 +287,8 @@ impl<'input> Display for TypedStmt<'input> {
                 post.clone().map_or(String::new(), |x| x.to_string()),
                 body.iter()
                     .map(|stmt| stmt
+                        .0
+                        .value()
                         .to_string()
                         .split('\n')
                         .map(|x| format!("    {x}"))
@@ -282,6 +303,8 @@ impl<'input> Display for TypedStmt<'input> {
                 stmts
                     .iter()
                     .map(|stmt| stmt
+                        .0
+                        .value()
                         .to_string()
                         .split('\n')
                         .map(|x| format!("    {x}"))

--- a/compiler/zrc_typeck/src/typeck/block.rs
+++ b/compiler/zrc_typeck/src/typeck/block.rs
@@ -490,8 +490,9 @@ pub fn type_block<'input>(
                                     TypedStmt(
                                         TypedStmtKind::IfStmt(
                                             typed_cond,
-                                            typed_then,
-                                            typed_then_else,
+                                            typed_then.in_span((*then).0.span()),
+                                            typed_then_else
+                                                .map(|te| te.in_span(then_else.unwrap().0.span())),
                                         )
                                         .in_span(stmt_span),
                                     ),
@@ -558,8 +559,11 @@ pub fn type_block<'input>(
 
                                 Ok(Some((
                                     TypedStmt(
-                                        TypedStmtKind::WhileStmt(typed_cond, typed_body)
-                                            .in_span(stmt_span),
+                                        TypedStmtKind::WhileStmt(
+                                            typed_cond,
+                                            typed_body.in_span(body.0.span()),
+                                        )
+                                        .in_span(stmt_span),
                                     ),
                                     match body_return_actuality {
                                         BlockReturnActuality::DoesNotReturn => {
@@ -646,7 +650,7 @@ pub fn type_block<'input>(
                                             init: typed_init.map(Box::new),
                                             cond: typed_cond,
                                             post: typed_post,
-                                            body: typed_body,
+                                            body: typed_body.in_span(body.0.span()),
                                         }
                                         .in_span(stmt_span),
                                     ),


### PR DESCRIPTION
attempts to add debuginfo to tast so we can use source-level debugging

closes #104
