### PR TITLE
fix(cg): make let declarations properly hoist

### DIFF
--- a/compiler/zrc_codegen/src/snapshots/zrc_codegen__expr__tests__cg_expr__regression_119_special_integer_literals.snap
+++ b/compiler/zrc_codegen/src/snapshots/zrc_codegen__expr__tests__cg_expr__regression_119_special_integer_literals.snap
@@ -8,9 +8,9 @@ source_filename = "test"
 
 define void @test() {
 entry:
+  %let_b = alloca i32, align 4
   %let_a = alloca i32, align 4
   store i32 10, ptr %let_a, align 4
-  %let_b = alloca i32, align 4
   store i32 8100, ptr %let_b, align 4
   ret void
 }

--- a/compiler/zrc_codegen/src/snapshots/zrc_codegen__stmt__tests__let_declarations_are_properly_generated.snap
+++ b/compiler/zrc_codegen/src/snapshots/zrc_codegen__stmt__tests__let_declarations_are_properly_generated.snap
@@ -8,8 +8,8 @@ source_filename = "test"
 
 define void @test() {
 entry:
-  %let_a = alloca i32, align 4
   %let_b = alloca i32, align 4
+  %let_a = alloca i32, align 4
   store i32 7, ptr %let_b, align 4
   ret void
 }

--- a/compiler/zrc_codegen/src/stmt.rs
+++ b/compiler/zrc_codegen/src/stmt.rs
@@ -63,6 +63,7 @@ fn cg_let_declaration<'ctx, 'input, 'a>(
 
         let entry_block_builder = ctx.create_builder();
         let first_bb = function.get_first_basic_block().unwrap();
+        #[allow(clippy::option_if_let_else)]
         match first_bb.get_first_instruction() {
             Some(first_instruction) => {
                 entry_block_builder.position_before(&first_instruction);

--- a/compiler/zrc_codegen/src/stmt.rs
+++ b/compiler/zrc_codegen/src/stmt.rs
@@ -58,8 +58,8 @@ fn cg_let_declaration<'ctx, 'input, 'a>(
 
     for let_declaration in declarations {
         // we create our own builder here because we need to insert the alloca
-        // at the beginning of the entry block, and that is easier than trying to somehow
-        // save our position.
+        // at the beginning of the entry block, and that is easier than trying to
+        // somehow save our position.
 
         let entry_block_builder = ctx.create_builder();
         let first_bb = function.get_first_basic_block().unwrap();


### PR DESCRIPTION
fixes #139: let declarations were not originally
being moved to the top of their bb making them not
qualify for SROA.
