### PR TITLE
feat: support `\t` and `\0` escapes

### DIFF
--- a/compiler/zrc_codegen/src/expr.rs
+++ b/compiler/zrc_codegen/src/expr.rs
@@ -149,6 +149,8 @@ pub(crate) fn cg_expr<'ctx, 'a>(
                     StringTok::EscapedBackslash => "\\".to_string(),
                     StringTok::EscapedCr => "\r".to_string(),
                     StringTok::EscapedNewline => "\n".to_string(),
+                    StringTok::EscapedTab => "\t".to_string(),
+                    StringTok::EscapedNull => "\0".to_string(),
                     StringTok::EscapedHexByte(byte) => {
                         format!(
                             "{}",
@@ -186,6 +188,8 @@ pub(crate) fn cg_expr<'ctx, 'a>(
                             StringTok::EscapedBackslash => '\\',
                             StringTok::EscapedCr => '\r',
                             StringTok::EscapedNewline => '\n',
+                            StringTok::EscapedTab => '\t',
+                            StringTok::EscapedNull => '\0',
                             StringTok::EscapedHexByte(byte) => {
                                 char::from_u32(byte.parse::<u32>().expect("invalid byte"))
                                     .expect("invalid char")
@@ -917,6 +921,18 @@ mod tests {
                     return;
                 }
             "});
+        }
+
+        #[test]
+        fn string_literal_escapes_generate() {
+            cg_snapshot_test!(indoc! {r#"
+                fn test() {
+                    // TEST: should properly generate \xNN for each escape
+                    let x = "\n\r\t\\\"\x41\0";
+                    
+                    return;
+                }
+            "#});
         }
 
         /// Tests to ensure non-decimal integer literals

--- a/compiler/zrc_codegen/src/expr.rs
+++ b/compiler/zrc_codegen/src/expr.rs
@@ -929,7 +929,7 @@ mod tests {
                 fn test() {
                     // TEST: should properly generate \xNN for each escape
                     let x = "\n\r\t\\\"\x41\0";
-                    
+
                     return;
                 }
             "#});

--- a/compiler/zrc_codegen/src/snapshots/zrc_codegen__expr__tests__cg_expr__string_literal_escapes_generate.snap
+++ b/compiler/zrc_codegen/src/snapshots/zrc_codegen__expr__tests__cg_expr__string_literal_escapes_generate.snap
@@ -1,0 +1,17 @@
+---
+source: compiler/zrc_codegen/src/expr.rs
+description: "fn test() {\n    // TEST: should properly generate \\xNN for each escape\n    let x = \"\\n\\r\\t\\\\\\\"\\x41\\0\";\n    \n    return;\n}\n"
+expression: resulting_ir
+---
+; ModuleID = 'test'
+source_filename = "test"
+
+@str = private unnamed_addr constant [7 x i8] c"\0A\0D\09\\\22)\00", align 1
+
+define void @test() {
+entry:
+  %let_x = alloca ptr, align 8
+  store ptr @str, ptr %let_x, align 8
+  ret void
+}
+

--- a/compiler/zrc_parser/src/lexer.rs
+++ b/compiler/zrc_parser/src/lexer.rs
@@ -546,6 +546,14 @@ pub enum StringTok<'input> {
     #[token("\\r")]
     EscapedCr,
 
+    /// `\t`
+    #[token("\\t")]
+    EscapedTab,
+
+    /// `\0`
+    #[token("\\0")]
+    EscapedNull,
+
     /// `\xXX` with `XX` being a hex literal
     #[regex(r"\\x[0-9a-fA-F]{2}", escaped_byte_slice)]
     EscapedHexByte(&'input str),
@@ -567,6 +575,8 @@ impl Display for StringTok<'_> {
         match self {
             Self::EscapedNewline => write!(f, "\\n"),
             Self::EscapedCr => write!(f, "\\r"),
+            Self::EscapedTab => write!(f, "\\t"),
+            Self::EscapedNull => write!(f, "\\0"),
             Self::EscapedBackslash => write!(f, "\\\\"),
             Self::EscapedHexByte(byte) => write!(f, "\\x{byte}"),
             Self::EscapedDoubleQuote => write!(f, "\\\""),


### PR DESCRIPTION
closes #125
