### PR TITLE
chore: forbid `unwrap` and rewrite them all to `expect`s

### DIFF
--- a/compiler/zrc/src/main.rs
+++ b/compiler/zrc/src/main.rs
@@ -40,7 +40,8 @@
     unsafe_op_in_unsafe_fn,
     unused_crate_dependencies,
     variant_size_differences,
-    unused_qualifications
+    unused_qualifications,
+    clippy::unwrap_used
 )]
 #![allow(clippy::multiple_crate_versions, clippy::cargo_common_metadata)]
 
@@ -104,7 +105,7 @@ fn version() -> String {
                                 .or_else(|| x.strip_suffix(" (staged)"))
                                 .unwrap_or(x)
                         })
-                        .unwrap();
+                        .expect("writing to a string should succeed");
                         output
                     })
             )
@@ -344,7 +345,9 @@ fn main() -> anyhow::Result<()> {
                     }
                 };
 
-            output.write_all(&x).unwrap();
+            output
+                .write_all(&x)
+                .expect("writing to stdout or file should succeed");
         }
     }
 

--- a/compiler/zrc_codegen/src/lib.rs
+++ b/compiler/zrc_codegen/src/lib.rs
@@ -41,6 +41,7 @@
     unused_crate_dependencies,
     variant_size_differences,
     unused_qualifications,
+    clippy::unwrap_used,
 
     // These should be enabled in any non-user-facing code, like the parser, but not in the
     // frontend.

--- a/compiler/zrc_codegen/src/test_utils.rs
+++ b/compiler/zrc_codegen/src/test_utils.rs
@@ -27,8 +27,8 @@ macro_rules! cg_snapshot_test {
         let resulting_ir = $crate::cg_program_to_string(
             "test",
             ::zrc_typeck::typeck::type_program(
-                ::zrc_parser::parser::parse_program($source).unwrap()
-            ).unwrap(),
+                ::zrc_parser::parser::parse_program($source).expect("parsing should succeed")
+            ).expect("typeck should succeed"),
             ::inkwell::OptimizationLevel::None,
             &$crate::get_native_triple(),
             "",

--- a/compiler/zrc_diagnostics/src/lib.rs
+++ b/compiler/zrc_diagnostics/src/lib.rs
@@ -41,6 +41,7 @@
     unused_crate_dependencies,
     variant_size_differences,
     unused_qualifications,
+    clippy::unwrap_used,
 
     // These should be enabled in any non-user-facing code, like the parser, but not in the
     // frontend.

--- a/compiler/zrc_parser/build.rs
+++ b/compiler/zrc_parser/build.rs
@@ -2,5 +2,5 @@ extern crate lalrpop;
 
 fn main() {
     // Generate the LR parser from our grammar
-    lalrpop::process_root().unwrap();
+    lalrpop::process_root().expect("LALRPOP build should not error");
 }

--- a/compiler/zrc_parser/src/lexer.rs
+++ b/compiler/zrc_parser/src/lexer.rs
@@ -642,7 +642,9 @@ mod tests {
     #[test]
     fn whitespace_should_be_skipped() {
         let lexer = ZircoLexer::new(" t\t e \n\ns\nt\r\n  s");
-        let tokens: Vec<_> = lexer.map(|x| x.transpose().unwrap()).collect();
+        let tokens: Vec<_> = lexer
+            .map(|x| x.transpose().expect("lexing should succeed"))
+            .collect();
         assert_eq!(
             tokens,
             vec![
@@ -744,7 +746,7 @@ mod tests {
 
         assert_eq!(
             ZircoLexer::new(input)
-                .map(|x| x.transpose().unwrap().into_value())
+                .map(|x| x.transpose().expect("lexing should succeed").into_value())
                 .collect::<Vec<_>>(),
             tokens
         );
@@ -773,7 +775,9 @@ mod tests {
                 "c // ghi\n",
                 "// jkl",
             ));
-            let tokens: Vec<_> = lexer.map(|x| x.transpose().unwrap()).collect();
+            let tokens: Vec<_> = lexer
+                .map(|x| x.transpose().expect("lexing should succeed"))
+                .collect();
             assert_eq!(
                 tokens,
                 vec![
@@ -788,7 +792,9 @@ mod tests {
         #[test]
         fn multiline_comments_are_skipped() {
             let lexer = ZircoLexer::new("a\nb/* abc */c/*\naaa\n*/d");
-            let tokens: Vec<_> = lexer.map(|x| x.transpose().unwrap()).collect();
+            let tokens: Vec<_> = lexer
+                .map(|x| x.transpose().expect("lexing should succeed"))
+                .collect();
             assert_eq!(
                 tokens,
                 vec![
@@ -804,7 +810,9 @@ mod tests {
         #[test]
         fn nested_multiline_comments_are_skipped() {
             let lexer = ZircoLexer::new("a/* /* */ */b"); // should lex OK
-            let tokens: Vec<_> = lexer.map(|x| x.transpose().unwrap()).collect();
+            let tokens: Vec<_> = lexer
+                .map(|x| x.transpose().expect("lexing should succeed"))
+                .collect();
             assert_eq!(
                 tokens,
                 vec![

--- a/compiler/zrc_parser/src/lib.rs
+++ b/compiler/zrc_parser/src/lib.rs
@@ -41,6 +41,7 @@
     unused_crate_dependencies,
     variant_size_differences,
     unused_qualifications,
+    clippy::unwrap_used,
 
     // These should be enabled in any non-user-facing code, like the parser, but not in the
     // frontend.

--- a/compiler/zrc_typeck/src/lib.rs
+++ b/compiler/zrc_typeck/src/lib.rs
@@ -45,6 +45,7 @@
     unused_crate_dependencies,
     variant_size_differences,
     unused_qualifications,
+    clippy::unwrap_used,
 
     // These should be enabled in any non-user-facing code, like the parser, but not in the
     // frontend.

--- a/compiler/zrc_typeck/src/typeck/block.rs
+++ b/compiler/zrc_typeck/src/typeck/block.rs
@@ -602,12 +602,12 @@ pub fn type_block<'input>(
                                     if inner_t_cond.inferred_type != TastType::Bool {
                                         return Err(Diagnostic(
                                             Severity::Error,
-                                            cond_span.unwrap().containing(
-                                                DiagnosticKind::ExpectedGot {
+                                            cond_span
+                                                .expect("span should exist if we unwrapped it")
+                                                .containing(DiagnosticKind::ExpectedGot {
                                                     expected: "bool".to_string(),
                                                     got: inner_t_cond.inferred_type.to_string(),
-                                                },
-                                            ),
+                                                }),
                                         ));
                                     }
                                 }
@@ -751,12 +751,12 @@ pub fn type_block<'input>(
                                         } else {
                                             Err(Diagnostic(
                                                 Severity::Error,
-                                                value_span.unwrap().containing(
-                                                    DiagnosticKind::ExpectedGot {
+                                                value_span
+                                                    .expect("value should exist if we unwrapped it")
+                                                    .containing(DiagnosticKind::ExpectedGot {
                                                         expected: return_ty.to_string(),
                                                         got: inferred_type.to_string(),
-                                                    },
-                                                ),
+                                                    }),
                                             ))
                                         }
                                     }

--- a/compiler/zrc_utils/src/lib.rs
+++ b/compiler/zrc_utils/src/lib.rs
@@ -34,6 +34,7 @@
     clippy::unneeded_field_pattern,
     clippy::wildcard_enum_match_arm,
     unused_qualifications,
+    clippy::unwrap_used,
 
     // These should be enabled in any non-user-facing code, like the parser, but not in the
     // frontend.


### PR DESCRIPTION
This should make ICEs more clear.
