### PR TITLE
fix(diagnostics): prevent negative-length-span on empty block

### DIFF
--- a/compiler/zrc_diagnostics/src/lib.rs
+++ b/compiler/zrc_diagnostics/src/lib.rs
@@ -204,7 +204,7 @@ fn display_source_window(severity: &Severity, span: Span, source: &str) -> Strin
         .filter(|(_, line)| {
             Span::intersect(
                 Span::from_positions(line.start(), line.ending()),
-                Span::from_positions(span.start(), span.end() - 1),
+                Span::from_positions(span.start(), span.end()),
             )
             .is_some()
         })

--- a/compiler/zrc_parser/src/internal_parser.lalrpop
+++ b/compiler/zrc_parser/src/internal_parser.lalrpop
@@ -105,9 +105,8 @@ Declaration: Declaration<'input> = {
 };
 
 FunctionDeclaration: Declaration<'input> = {
-    "fn" <i:Spanned<IDENTIFIER>> "(" <a:Spanned<ArgumentDeclarationList?>> ")" <r:("->" <Type>)?> "{"
-        <s:Spanned<StmtList?>>
-    "}" => Declaration::FunctionDeclaration {
+    "fn" <i:Spanned<IDENTIFIER>> "(" <a:Spanned<ArgumentDeclarationList?>> ")" <r:("->" <Type>)?>
+        <s:Spanned<("{" <StmtList?> "}")>> => Declaration::FunctionDeclaration {
         name: i,
         parameters: a.map(|inner| inner.unwrap_or(ArgumentDeclarationList::empty())),
         return_type: r,


### PR DESCRIPTION
Originally, the span code would for whatever reason subtract 1 from the
end of the span. This probably had a reason but I'm not sure -- I may
have just introduced a bug, but it's display code so it's not super
important. If I did, it'll be fixed by #134 if we switch to
codespan-reporting.

The diagnostic also highlighted the body of a function oddly:
```
fn f() { ... }
//       ^^^ span
```

This commit changes the function body to be represented by:
```
fn f() { ... }
//     ^^^^^^^
```

Hence, double-fixing this bug.

closes #137
