### PR TITLE
fix: disallow double-comma in ArgumentDeclarationList

### DIFF
--- a/compiler/zrc_parser/src/internal_parser.lalrpop
+++ b/compiler/zrc_parser/src/internal_parser.lalrpop
@@ -32,6 +32,7 @@ CommaSeparated<T>: Vec<T> = {
     }
 };
 
+#[inline]
 CommaSeparatedWithoutTrailing<T>: Vec<T> = {
     <e:T> <mut v:("," <T>)*> => {
         let mut new = vec![e];
@@ -146,7 +147,7 @@ StructOrUnionDeclaration: Declaration<'input> = {
 
 ArgumentDeclarationList: ArgumentDeclarationList<'input> = {
     <CommaSeparated<Spanned<ArgumentDeclaration>>> => ArgumentDeclarationList::NonVariadic(<>),
-    <CommaSeparated<Spanned<ArgumentDeclaration>>> "," "..." => ArgumentDeclarationList::Variadic(<>),
+    <CommaSeparatedWithoutTrailing<Spanned<ArgumentDeclaration>>> "," "..." => ArgumentDeclarationList::Variadic(<>),
 };
 
 ArgumentDeclaration: ArgumentDeclaration<'input> = {


### PR DESCRIPTION
Fixes #154
