### PR TITLE
chore: remove redundant import of `ToString`

### DIFF
--- a/compiler/zrc_parser/src/ast/expr.rs
+++ b/compiler/zrc_parser/src/ast/expr.rs
@@ -2,7 +2,7 @@
 //!
 //! The main thing within this module you will need is the [`Expr`] struct.
 
-use std::{fmt::Display, string::ToString};
+use std::fmt::Display;
 
 use zrc_utils::{
     span::{Span, Spannable, Spanned},

--- a/compiler/zrc_parser/src/lexer.rs
+++ b/compiler/zrc_parser/src/lexer.rs
@@ -31,7 +31,7 @@
 //!
 //! For more information, read the documentation of [`ZircoLexer`].
 
-use std::{fmt::Display, string::ToString};
+use std::fmt::Display;
 
 use logos::{Lexer, Logos};
 use zrc_utils::span::{Span, Spanned};


### PR DESCRIPTION
Multiple builds were failing due to this redundant import error in two files.