### PR TITLE
chore: resolve clippy lints

### DIFF
--- a/compiler/zrc_parser/src/ast/expr.rs
+++ b/compiler/zrc_parser/src/ast/expr.rs
@@ -2,7 +2,7 @@
 //!
 //! The main thing within this module you will need is the [`Expr`] struct.
 
-use std::{fmt::Display, string::ToString};
+use std::fmt::Display;
 
 use zrc_utils::{
     span::{Span, Spannable, Spanned},

--- a/compiler/zrc_parser/src/lexer.rs
+++ b/compiler/zrc_parser/src/lexer.rs
@@ -31,7 +31,7 @@
 //!
 //! For more information, read the documentation of [`ZircoLexer`].
 
-use std::{fmt::Display, string::ToString};
+use std::fmt::Display;
 
 use logos::{Lexer, Logos};
 use zrc_utils::span::{Span, Spanned};

--- a/compiler/zrc_typeck/src/tast/expr.rs
+++ b/compiler/zrc_typeck/src/tast/expr.rs
@@ -1,6 +1,6 @@
 //! Expression representation for the Zirco [TAST](super)
 
-use std::{fmt::Display, string::ToString};
+use std::fmt::Display;
 
 pub use zrc_parser::{
     ast::expr::{Arithmetic, BinaryBitwise, Comparison, Equality, Logical},

--- a/compiler/zrc_typeck/src/tast/stmt.rs
+++ b/compiler/zrc_typeck/src/tast/stmt.rs
@@ -1,6 +1,6 @@
 //! Statement representation for the Zirco [TAST](super)
 
-use std::{fmt::Display, string::ToString};
+use std::fmt::Display;
 
 use zrc_utils::span::Spanned;
 

--- a/compiler/zrc_typeck/src/typeck/declaration.rs
+++ b/compiler/zrc_typeck/src/typeck/declaration.rs
@@ -309,13 +309,7 @@ mod tests {
     use zrc_utils::spanned;
 
     use super::*;
-    use crate::{
-        tast::ty::FunctionDeclarationGlobalMetadata,
-        typeck::{
-            declaration::process_declaration,
-            scope::{TypeCtx, ValueCtx},
-        },
-    };
+    use crate::typeck::scope::{TypeCtx, ValueCtx};
 
     #[test]
     fn re_declaration_works_as_expected() {

--- a/compiler/zrc_typeck/src/typeck/expr.rs
+++ b/compiler/zrc_typeck/src/typeck/expr.rs
@@ -639,7 +639,7 @@ pub fn type_expr<'input>(
 mod tests {
     use zrc_diagnostics::Severity;
     use zrc_parser::lexer::NumberLiteral;
-    use zrc_utils::{span::Spannable, spanned};
+    use zrc_utils::spanned;
 
     use super::*;
 
@@ -678,8 +678,6 @@ mod tests {
     }
 
     mod desugar_assignment {
-        use zrc_parser::ast::expr::Arithmetic;
-
         use super::*;
 
         #[test]

--- a/compiler/zrc_typeck/src/typeck/scope.rs
+++ b/compiler/zrc_typeck/src/typeck/scope.rs
@@ -8,7 +8,7 @@ use crate::tast::ty::{FunctionDeclarationGlobalMetadata, Type as TastType};
 /// name to its internal [`TastType`] representation.
 #[derive(Debug, Clone)]
 pub struct TypeCtx<'input> {
-    /// Mappings from type name to its [TastType]
+    /// Mappings from type name to its [`TastType`]
     mappings: HashMap<&'input str, TastType<'input>>,
 }
 impl<'input> TypeCtx<'input> {
@@ -89,7 +89,7 @@ where
 
 #[derive(Debug, Clone)]
 pub struct ValueCtx<'input> {
-    /// Mappings from identifier to its contained data [TastType]
+    /// Mappings from identifier to its contained data [`TastType`]
     mappings: HashMap<&'input str, TastType<'input>>,
 }
 impl<'input> ValueCtx<'input> {

--- a/compiler/zrc_typeck/src/typeck/ty.rs
+++ b/compiler/zrc_typeck/src/typeck/ty.rs
@@ -66,7 +66,6 @@ pub(super) fn resolve_key_type_mapping<'input>(
 #[cfg(test)]
 mod tests {
     use zrc_diagnostics::Severity;
-    use zrc_parser::ast::ty::KeyTypeMapping;
     use zrc_utils::{span::Span, spanned};
 
     use super::*;


### PR DESCRIPTION
something went wrong with the build process and all of these lints went
under the radar in the past rustc version. now that i've updated my own
nightly toolchain i was able to resolve all of these lints so hopefully*
builds will pass now

supersedes #190
