### PR TITLE
chore: remove `Display` impl from tast

### DIFF
--- a/compiler/zrc/src/main.rs
+++ b/compiler/zrc/src/main.rs
@@ -211,8 +211,6 @@ enum OutputFormat {
     TastDebug,
     /// The Zirco TAST, in Rust-like format with indentation
     TastDebugPretty,
-    /// The Zirco TAST, stringified to Zirco-like code
-    Tast,
     /// Assembly
     Asm,
     /// Object file
@@ -227,7 +225,6 @@ impl Display for OutputFormat {
             Self::Ast => write!(f, "ast"),
             Self::TastDebug => write!(f, "tast-debug"),
             Self::TastDebugPretty => write!(f, "tast-debug-pretty"),
-            Self::Tast => write!(f, "tast"),
             Self::Asm => write!(f, "asm"),
             Self::Object => write!(f, "object"),
         }
@@ -429,14 +426,9 @@ fn compile(
     // display the TAST if the user wants it
     if matches!(
         emit,
-        OutputFormat::Tast | OutputFormat::TastDebug | OutputFormat::TastDebugPretty,
+        OutputFormat::TastDebug | OutputFormat::TastDebugPretty,
     ) {
         return Ok(match *emit {
-            OutputFormat::Tast => typed_ast
-                .into_iter()
-                .map(|x| x.value().to_string())
-                .collect::<Vec<_>>()
-                .join("\n"),
             OutputFormat::TastDebug => format!("{typed_ast:?}"),
             OutputFormat::TastDebugPretty => format!("{typed_ast:#?}"),
 

--- a/compiler/zrc_typeck/src/tast/expr.rs
+++ b/compiler/zrc_typeck/src/tast/expr.rs
@@ -1,7 +1,5 @@
 //! Expression representation for the Zirco [TAST](super)
 
-use std::fmt::Display;
-
 use zrc_parser::lexer::ZrcString;
 pub use zrc_parser::{
     ast::expr::{Arithmetic, BinaryBitwise, Comparison, Equality, Logical},
@@ -18,11 +16,6 @@ pub struct Place<'input> {
     pub inferred_type: Type<'input>,
     /// The actual [`PlaceKind`] backing this expression
     pub kind: Spanned<PlaceKind<'input>>,
-}
-impl<'input> Display for Place<'input> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "({}) as ({})", self.inferred_type, self.kind)
-    }
 }
 
 /// The valid left-hand-side of a [`TypedExprKind::Assignment`].
@@ -41,16 +34,6 @@ pub enum PlaceKind<'input> {
     /// `x.y`
     Dot(Box<Place<'input>>, Spanned<&'input str>),
 }
-impl<'input> Display for PlaceKind<'input> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Deref(expr) => write!(f, "*{expr}"),
-            Self::Variable(ident) => write!(f, "{ident}"),
-            Self::Index(ptr, idx) => write!(f, "{ptr}[{idx}]"),
-            Self::Dot(expr, key) => write!(f, "{expr}.{key}"),
-        }
-    }
-}
 
 /// An [expression kind](TypedExprKind) with its yielded [result
 /// type](super::ty::Type) attached to it.
@@ -60,11 +43,6 @@ pub struct TypedExpr<'input> {
     pub inferred_type: Type<'input>,
     /// The actual [`TypedExprKind`] backing this expression
     pub kind: Spanned<TypedExprKind<'input>>,
-}
-impl<'input> Display for TypedExpr<'input> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "(({}) as ({}))", self.inferred_type, self.kind)
-    }
 }
 
 /// The kind of a [`TypedExpr`]
@@ -133,40 +111,4 @@ pub enum TypedExprKind<'input> {
     Identifier(&'input str),
     /// Any boolean literal.
     BooleanLiteral(bool),
-}
-impl<'input> Display for TypedExprKind<'input> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::NumberLiteral(n) => write!(f, "{n}"),
-            Self::StringLiteral(str) => write!(f, "\"{str}\"",),
-            Self::CharLiteral(str) => write!(f, "\'{str}\'"),
-            Self::Identifier(i) => write!(f, "{i}"),
-            Self::BooleanLiteral(value) => write!(f, "{value}"),
-            Self::Assignment(place, value) => write!(f, "{place} = {value}"),
-            Self::Equality(operator, lhs, rhs) => write!(f, "{lhs} {operator} {rhs}"),
-            Self::Comparison(operator, lhs, rhs) => write!(f, "{lhs} {operator} {rhs}"),
-            Self::Arithmetic(operator, lhs, rhs) => write!(f, "{lhs} {operator} {rhs}"),
-            Self::BinaryBitwise(operator, lhs, rhs) => write!(f, "{lhs} {operator} {rhs}"),
-            Self::Logical(operator, lhs, rhs) => write!(f, "{lhs} {operator} {rhs}"),
-            Self::Comma(lhs, rhs) => write!(f, "{lhs}, {rhs}"),
-            Self::UnaryNot(expr) => write!(f, "!{expr}"),
-            Self::UnaryBitwiseNot(expr) => write!(f, "~{expr}"),
-            Self::UnaryMinus(expr) => write!(f, "-{expr}"),
-            Self::UnaryAddressOf(expr) => write!(f, "&{expr}"),
-            Self::UnaryDereference(expr) => write!(f, "*{expr}"),
-            Self::Ternary(cond, if_true, if_false) => write!(f, "{cond} ? {if_true} : {if_false}"),
-            Self::Index(ptr, idx) => write!(f, "{ptr}[{idx}]"),
-            Self::Dot(expr, key) => write!(f, "{expr}.{key}"),
-            Self::Cast(expr, ty) => write!(f, "{expr} as {ty}"),
-            Self::SizeOf(ty) => write!(f, "sizeof({ty})"),
-            Self::Call(expr, args) => write!(
-                f,
-                "{expr}({})",
-                args.iter()
-                    .map(ToString::to_string)
-                    .collect::<Vec<String>>()
-                    .join(", ")
-            ),
-        }
-    }
 }

--- a/compiler/zrc_typeck/src/typeck/expr.rs
+++ b/compiler/zrc_typeck/src/typeck/expr.rs
@@ -46,7 +46,7 @@ fn desugar_assignment<'input>(
 /// Validate an expr into a place
 fn expr_to_place(span: Span, expr: TypedExpr) -> Result<Place, Diagnostic> {
     let kind_span = expr.kind.span();
-    let stringified = expr.to_string();
+    let stringified = expr.inferred_type.to_string();
 
     #[allow(clippy::wildcard_enum_match_arm)]
     Ok(match expr.kind.into_value() {
@@ -271,16 +271,16 @@ pub fn type_expr<'input>(
                     }
                 } else {
                     return Err(DiagnosticKind::StructOrUnionDoesNotHaveMember(
-                        obj_t.to_string(),
+                        obj_t.inferred_type.to_string(),
                         key.into_value().to_string(),
                     )
                     .error_in(expr_span));
                 }
             } else {
-                return Err(
-                    DiagnosticKind::StructMemberAccessOnNonStruct(obj_t.to_string())
-                        .error_in(expr_span),
-                );
+                return Err(DiagnosticKind::StructMemberAccessOnNonStruct(
+                    obj_t.inferred_type.to_string(),
+                )
+                .error_in(expr_span));
             }
         }
         ExprKind::Arrow(obj, key) => {
@@ -300,10 +300,10 @@ pub fn type_expr<'input>(
                     )),
                 )?
             } else {
-                return Err(
-                    DiagnosticKind::CannotDereferenceNonPointer(obj_t.to_string())
-                        .error_in(expr_span),
-                );
+                return Err(DiagnosticKind::CannotDereferenceNonPointer(
+                    obj_t.inferred_type.to_string(),
+                )
+                .error_in(expr_span));
             }
         }
         ExprKind::Call(f, args) => {
@@ -381,9 +381,10 @@ pub fn type_expr<'input>(
                     }
                 }
                 _ => {
-                    return Err(
-                        DiagnosticKind::CannotCallNonFunction(ft.to_string()).error_in(expr_span)
-                    );
+                    return Err(DiagnosticKind::CannotCallNonFunction(
+                        ft.inferred_type.to_string(),
+                    )
+                    .error_in(expr_span));
                 }
             }
         }


### PR DESCRIPTION
this was unused and is hence just extra code we don't need
