### PR TITLE
feat: add integer literals with explicitly specified types

### DIFF
--- a/compiler/zrc_codegen/src/expr.rs
+++ b/compiler/zrc_codegen/src/expr.rs
@@ -207,7 +207,7 @@ pub(crate) fn cg_expr<'ctx>(
     cg.builder.set_current_debug_location(debug_location);
 
     match expr.kind.into_value() {
-        TypedExprKind::NumberLiteral(n) => {
+        TypedExprKind::NumberLiteral(n, _) => {
             let no_underscores = n.text_content().replace('_', "");
 
             bb.and(
@@ -783,6 +783,16 @@ mod tests {
     }
     mod cg_expr {
         use super::*;
+
+        #[test]
+        fn typed_integers_generate_properly() {
+            cg_snapshot_test!(indoc! {"
+                fn test() -> i8 {
+                    // TEST: returns `i8`
+                    return 4i8;
+                }
+            "});
+        }
 
         #[test]
         fn comma_yields_right_value() {

--- a/compiler/zrc_codegen/src/snapshots/zrc_codegen__expr__tests__cg_expr__typed_integers_generate_properly.snap
+++ b/compiler/zrc_codegen/src/snapshots/zrc_codegen__expr__tests__cg_expr__typed_integers_generate_properly.snap
@@ -1,0 +1,27 @@
+---
+source: compiler/zrc_codegen/src/expr.rs
+description: "fn test() -> i8 {\n    // TEST: returns `i8`\n    return 4i8;\n}\n"
+expression: resulting_ir
+---
+; ModuleID = 'test.zr'
+source_filename = "test.zr"
+
+define i8 @test() !dbg !3 {
+entry:
+  ret i8 4, !dbg !8
+}
+
+!llvm.module.flags = !{!0}
+!llvm.dbg.cu = !{!1}
+
+!0 = !{i32 2, !"Debug Info Version", i32 3}
+!1 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "zrc test runner", isOptimized: false, flags: "zrc --fake-args", runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false)
+!2 = !DIFile(filename: "test.zr", directory: "/fake/path")
+!3 = distinct !DISubprogram(name: "test", linkageName: "test", scope: null, file: !2, line: 1, type: !4, scopeLine: 1, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !7)
+!4 = !DISubroutineType(types: !5)
+!5 = !{!6}
+!6 = !DIBasicType(name: "i8")
+!7 = !{}
+!8 = !DILocation(line: 3, column: 12, scope: !9)
+!9 = distinct !DILexicalBlock(scope: !10, file: !2, line: 1, column: 17)
+!10 = distinct !DILexicalBlock(scope: !3, file: !2, line: 1, column: 17)

--- a/compiler/zrc_diagnostics/src/lib.rs
+++ b/compiler/zrc_diagnostics/src/lib.rs
@@ -204,6 +204,8 @@ pub enum DiagnosticKind {
     ConflictingFunctionDeclarations(String, String),
     #[error("function {0} has multiple implementations in this unit")]
     ConflictingImplementations(String),
+    #[error("type {0} cannot be used for number literals")]
+    InvalidNumberLiteralType(String),
 }
 impl DiagnosticKind {
     /// Create an [error] diagnostic in a given [`Span`]

--- a/compiler/zrc_parser/src/internal_parser.lalrpop
+++ b/compiler/zrc_parser/src/internal_parser.lalrpop
@@ -316,7 +316,7 @@ Postfix: Expr<'input> = ExprPrecedenceTier<_Postfix, Primary>;
 ArgumentList: Vec<Expr<'input>> = CommaSeparated<Assignment>;
 
 Primary: Expr<'input> = {
-    Spanned<NUMBER> => Expr(<>.map(|n| ExprKind::NumberLiteral(n))),
+    Spanned<(<NUMBER> <Spanned<IDENTIFIER>?>)> => Expr(<>.map(|(n, ty)| ExprKind::NumberLiteral(n, ty.map(|t| Type(t.map(TypeKind::Identifier)))))),
     Spanned<STRING> => Expr(<>.map(|s| ExprKind::StringLiteral(s))),
     Spanned<CHAR> => Expr(<>.map(|c| ExprKind::CharLiteral(c))),
     Spanned<IDENTIFIER> => Expr(<>.map(|i| ExprKind::Identifier(i))),

--- a/compiler/zrc_parser/src/lexer.rs
+++ b/compiler/zrc_parser/src/lexer.rs
@@ -206,6 +206,16 @@ impl<'input> NumberLiteral<'input> {
             Self::Decimal(n) | Self::Hexadecimal(n) | Self::Binary(n) => n,
         }
     }
+
+    /// Convert a [`NumberLiteral`] into its radix (2, 10, or 16)
+    #[must_use]
+    pub const fn radix(&self) -> u32 {
+        match self {
+            Self::Decimal(_) => 10,
+            Self::Hexadecimal(_) => 16,
+            Self::Binary(_) => 2,
+        }
+    }
 }
 impl Display for NumberLiteral<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/compiler/zrc_parser/src/parser.rs
+++ b/compiler/zrc_parser/src/parser.rs
@@ -195,18 +195,18 @@ mod tests {
                 parse_expr("1 + 1 - 1 * 1 / 1 % 1"),
                 Ok(Expr::build_sub(
                     Expr::build_add(
-                        Expr::build_number_dec(spanned!(0, "1", 1)),
-                        Expr::build_number_dec(spanned!(4, "1", 5))
+                        Expr::build_number_dec(spanned!(0, "1", 1), None),
+                        Expr::build_number_dec(spanned!(4, "1", 5), None)
                     ),
                     Expr::build_modulo(
                         Expr::build_div(
                             Expr::build_mul(
-                                Expr::build_number_dec(spanned!(8, "1", 9)),
-                                Expr::build_number_dec(spanned!(12, "1", 13))
+                                Expr::build_number_dec(spanned!(8, "1", 9), None),
+                                Expr::build_number_dec(spanned!(12, "1", 13), None)
                             ),
-                            Expr::build_number_dec(spanned!(16, "1", 17))
+                            Expr::build_number_dec(spanned!(16, "1", 17), None)
                         ),
-                        Expr::build_number_dec(spanned!(20, "1", 21))
+                        Expr::build_number_dec(spanned!(20, "1", 21), None)
                     )
                 ))
             );
@@ -218,17 +218,17 @@ mod tests {
                 parse_expr("1 & 1 | 1 ^ 1 << 1 >> 1"),
                 Ok(Expr::build_bit_or(
                     Expr::build_bit_and(
-                        Expr::build_number_dec(spanned!(0, "1", 1)),
-                        Expr::build_number_dec(spanned!(4, "1", 5))
+                        Expr::build_number_dec(spanned!(0, "1", 1), None),
+                        Expr::build_number_dec(spanned!(4, "1", 5), None)
                     ),
                     Expr::build_bit_xor(
-                        Expr::build_number_dec(spanned!(8, "1", 9)),
+                        Expr::build_number_dec(spanned!(8, "1", 9), None),
                         Expr::build_shr(
                             Expr::build_shl(
-                                Expr::build_number_dec(spanned!(12, "1", 13)),
-                                Expr::build_number_dec(spanned!(17, "1", 18))
+                                Expr::build_number_dec(spanned!(12, "1", 13), None),
+                                Expr::build_number_dec(spanned!(17, "1", 18), None)
                             ),
-                            Expr::build_number_dec(spanned!(22, "1", 23))
+                            Expr::build_number_dec(spanned!(22, "1", 23), None)
                         )
                     )
                 ))
@@ -241,10 +241,10 @@ mod tests {
                 parse_expr("1 && 1 || 1"),
                 Ok(Expr::build_logical_or(
                     Expr::build_logical_and(
-                        Expr::build_number_dec(spanned!(0, "1", 1)),
-                        Expr::build_number_dec(spanned!(5, "1", 6))
+                        Expr::build_number_dec(spanned!(0, "1", 1), None),
+                        Expr::build_number_dec(spanned!(5, "1", 6), None)
                     ),
-                    Expr::build_number_dec(spanned!(10, "1", 11))
+                    Expr::build_number_dec(spanned!(10, "1", 11), None)
                 ))
             );
         }
@@ -255,10 +255,10 @@ mod tests {
                 parse_expr("1 == 1 != 1"),
                 Ok(Expr::build_neq(
                     Expr::build_eq(
-                        Expr::build_number_dec(spanned!(0, "1", 1)),
-                        Expr::build_number_dec(spanned!(5, "1", 6))
+                        Expr::build_number_dec(spanned!(0, "1", 1), None),
+                        Expr::build_number_dec(spanned!(5, "1", 6), None)
                     ),
-                    Expr::build_number_dec(spanned!(10, "1", 11))
+                    Expr::build_number_dec(spanned!(10, "1", 11), None)
                 ))
             );
         }
@@ -271,14 +271,14 @@ mod tests {
                     Expr::build_lt(
                         Expr::build_gte(
                             Expr::build_gt(
-                                Expr::build_number_dec(spanned!(0, "1", 1)),
-                                Expr::build_number_dec(spanned!(4, "1", 5))
+                                Expr::build_number_dec(spanned!(0, "1", 1), None),
+                                Expr::build_number_dec(spanned!(4, "1", 5), None)
                             ),
-                            Expr::build_number_dec(spanned!(9, "1", 10))
+                            Expr::build_number_dec(spanned!(9, "1", 10), None)
                         ),
-                        Expr::build_number_dec(spanned!(13, "1", 14))
+                        Expr::build_number_dec(spanned!(13, "1", 14), None)
                     ),
-                    Expr::build_number_dec(spanned!(18, "1", 19))
+                    Expr::build_number_dec(spanned!(18, "1", 19), None)
                 ))
             );
         }
@@ -374,7 +374,7 @@ mod tests {
             fn number_literals_parse_as_expected() {
                 assert_eq!(
                     parse_expr("1"),
-                    Ok(Expr::build_number_dec(spanned!(0, "1", 1)))
+                    Ok(Expr::build_number_dec(spanned!(0, "1", 1), None))
                 );
             }
 

--- a/compiler/zrc_typeck/src/tast/expr.rs
+++ b/compiler/zrc_typeck/src/tast/expr.rs
@@ -102,7 +102,7 @@ pub enum TypedExprKind<'input> {
     SizeOf(Type<'input>),
 
     /// Any numeric literal.
-    NumberLiteral(NumberLiteral<'input>),
+    NumberLiteral(NumberLiteral<'input>, Type<'input>),
     /// Any string literal.
     StringLiteral(ZrcString<'input>),
     /// Any char literal

--- a/compiler/zrc_typeck/src/typeck/scope.rs
+++ b/compiler/zrc_typeck/src/typeck/scope.rs
@@ -11,6 +11,22 @@ pub struct TypeCtx<'input> {
     /// Mappings from type name to its [`TastType`]
     mappings: HashMap<&'input str, TastType<'input>>,
 }
+/// All types namable in the global scope
+const ALL_NAMABLE_TYPES: [(&str, TastType); 11] = [
+    // all namable types
+    ("i8", TastType::I8),
+    ("u8", TastType::U8),
+    ("i16", TastType::I16),
+    ("u16", TastType::U16),
+    ("i32", TastType::I32),
+    ("u32", TastType::U32),
+    ("i64", TastType::I64),
+    ("u64", TastType::U64),
+    ("isize", TastType::Isize),
+    ("usize", TastType::Usize),
+    ("bool", TastType::Bool),
+    // void is not namable
+];
 impl<'input> TypeCtx<'input> {
     /// Create a new [`TypeScope`] containing **NOTHING** -- not even
     /// primitives.
@@ -24,21 +40,7 @@ impl<'input> TypeCtx<'input> {
     /// Create a new [`TypeScope`] containing just the primitives
     #[must_use]
     pub fn new() -> TypeCtx<'input> {
-        Self::from([
-            // all namable types
-            ("i8", TastType::I8),
-            ("u8", TastType::U8),
-            ("i16", TastType::I16),
-            ("u16", TastType::U16),
-            ("i32", TastType::I32),
-            ("u32", TastType::U32),
-            ("i64", TastType::I64),
-            ("u64", TastType::U64),
-            ("isize", TastType::Isize),
-            ("usize", TastType::Usize),
-            ("bool", TastType::Bool),
-            // void is not namable
-        ])
+        Self::from(ALL_NAMABLE_TYPES)
     }
 
     /// Create a new [`TypeScope`] from a [`HashMap`] mapping identifier [str]s
@@ -48,6 +50,17 @@ impl<'input> TypeCtx<'input> {
         mappings: HashMap<&'input str, TastType<'input>>,
     ) -> TypeCtx<'input> {
         Self { mappings }
+    }
+
+    /// Create a new [`TypeScope`] from a [`HashMap`] mapping identifier [str]s
+    /// to [`TastType`]s
+    #[must_use]
+    pub fn from_defaults_and_mappings(
+        mappings: HashMap<&'input str, TastType<'input>>,
+    ) -> TypeCtx<'input> {
+        Self {
+            mappings: ALL_NAMABLE_TYPES.iter().cloned().chain(mappings).collect(),
+        }
     }
 
     /// Determine if a type exists by a given name


### PR DESCRIPTION
closes #53 

adds types like `4u8`