### PR TITLE
ci: remove slow LLVM build process, LLVM is included in the environment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,10 +18,6 @@ jobs:
                   # Make sure the actual branch is checked out when running on pull requests
                   ref: ${{ github.head_ref }}
                   repository: ${{github.event.pull_request.head.repo.full_name || github.repository }}
-            - name: Install LLVM 16
-              run: |
-                  sudo apt-get update
-                  sudo apt-get install -y llvm-16 clang-16
             - name: Set up Rust
               uses: actions-rs/toolchain@v1
               with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,10 +18,10 @@ jobs:
                   # Make sure the actual branch is checked out when running on pull requests
                   ref: ${{ github.head_ref }}
                   repository: ${{github.event.pull_request.head.repo.full_name || github.repository }}
-            - name: Install LLVM
-              uses: KyleMayes/install-llvm-action@v2
-              with:
-                  version: "16.0"
+            - name: Install LLVM 16
+              run: |
+                  sudo apt-get update
+                  sudo apt-get install -y llvm-16 clang-16
             - name: Set up Rust
               uses: actions-rs/toolchain@v1
               with:

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -18,10 +18,6 @@ jobs:
                   # Make sure the actual branch is checked out when running on pull requests
                   ref: ${{ github.head_ref }}
                   repository: ${{github.event.pull_request.head.repo.full_name || github.repository }}
-            - name: Install LLVM 16
-              run: |
-                  sudo apt-get update
-                  sudo apt-get install -y llvm-16 clang-16
             - name: Set up Rust
               uses: actions-rs/toolchain@v1
               with:

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -18,10 +18,10 @@ jobs:
                   # Make sure the actual branch is checked out when running on pull requests
                   ref: ${{ github.head_ref }}
                   repository: ${{github.event.pull_request.head.repo.full_name || github.repository }}
-            - name: Install LLVM
-              uses: KyleMayes/install-llvm-action@v2
-              with:
-                  version: "16.0"
+            - name: Install LLVM 16
+              run: |
+                  sudo apt-get update
+                  sudo apt-get install -y llvm-16 clang-16
             - name: Set up Rust
               uses: actions-rs/toolchain@v1
               with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,10 +18,6 @@ jobs:
                   # Make sure the actual branch is checked out when running on pull requests
                   ref: ${{ github.head_ref }}
                   repository: ${{github.event.pull_request.head.repo.full_name || github.repository }}
-            - name: Install LLVM 16
-              run: |
-                  sudo apt-get update
-                  sudo apt-get install -y llvm-16 clang-16
             - name: Set up Rust
               uses: actions-rs/toolchain@v1
               with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,10 +18,10 @@ jobs:
                   # Make sure the actual branch is checked out when running on pull requests
                   ref: ${{ github.head_ref }}
                   repository: ${{github.event.pull_request.head.repo.full_name || github.repository }}
-            - name: Install LLVM
-              uses: KyleMayes/install-llvm-action@v2
-              with:
-                  version: "16.0"
+            - name: Install LLVM 16
+              run: |
+                  sudo apt-get update
+                  sudo apt-get install -y llvm-16 clang-16
             - name: Set up Rust
               uses: actions-rs/toolchain@v1
               with:


### PR DESCRIPTION
We previously would build LLVM for every action, but the runners now include it. No need to build!