### PR TITLE
fix(typeck): ensure the match conditions are the same type as the scrutinee

### DIFF
--- a/compiler/zrc_typeck/src/typeck/block/block_return.rs
+++ b/compiler/zrc_typeck/src/typeck/block/block_return.rs
@@ -90,4 +90,13 @@ impl BlockReturnActuality {
             (Self::AlwaysReturns, Self::AlwaysReturns) => Self::AlwaysReturns,
         }
     }
+
+    /// Join an iterator of [`BlockReturnActuality`] values.
+    #[must_use]
+    pub fn join_iter<I>(iter: I) -> Self
+    where
+        I: IntoIterator<Item = Self>,
+    {
+        iter.into_iter().fold(Self::NeverReturns, Self::join)
+    }
 }


### PR DESCRIPTION
fixes #297
