### PR TITLE
ci: only run the rustdoc comment on local PRs

### DIFF
--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -46,7 +46,7 @@ jobs:
                   path: target/doc/
                   retention-days: 7
             - name: Comment on PR with artifact link
-              if: github.event_name == 'pull_request'
+              if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
               uses: actions/github-script@v8
               with:
                   script: |


### PR DESCRIPTION
this fixes an error on many foreign PRs
