### PR TITLE
feat: add `four` statements

### DIFF
--- a/compiler/zrc_codegen/src/stmt.rs
+++ b/compiler/zrc_codegen/src/stmt.rs
@@ -214,6 +214,9 @@ pub(crate) fn cg_block<'ctx, 'input, 'a>(
                     post,
                     body,
                 )),
+                TypedStmtKind::FourStmt(body) => {
+                    Some(loops::cg_four_stmt(cg, bb, &scope, lexical_block, body))
+                }
 
                 TypedStmtKind::WhileStmt(cond, body) => {
                     Some(loops::cg_while_stmt(cg, &scope, lexical_block, cond, body))

--- a/compiler/zrc_parser/src/ast/stmt.rs
+++ b/compiler/zrc_parser/src/ast/stmt.rs
@@ -85,6 +85,8 @@ pub enum StmtKind<'input> {
         /// The body of the loop.
         body: Box<Stmt<'input>>,
     },
+    /// `four body`
+    FourStmt(Box<Stmt<'input>>),
     /// `{ ... }`
     BlockStmt(Vec<Stmt<'input>>),
     /// `x;`
@@ -149,6 +151,7 @@ impl Display for StmtKind<'_> {
                     post.as_ref().map_or(String::new(), ToString::to_string),
                 )
             }
+            Self::FourStmt(body) => write!(f, "four {body}"),
 
             Self::BlockStmt(stmts) => {
                 if stmts.is_empty() {
@@ -388,6 +391,8 @@ mod tests {
             "for (let x = 4; ; ) {\n    ;\n}",
             "for (let x = 4, y = 5; ; ) {\n    ;\n}",
             "for (let x = 4; true; ) {\n    ;\n}",
+            "four {\n    ;\n}",
+            "four return;",
             "let x;",
             "let x = 4;",
             "let x: i32;",

--- a/compiler/zrc_parser/src/internal_parser.lalrpop
+++ b/compiler/zrc_parser/src/internal_parser.lalrpop
@@ -69,6 +69,7 @@ OpenStmt: StmtKind<'input> = {
         post: c,
         body: Box::new(d)
     },
+    "four" <d:SpannedStmt<OpenStmt>> => StmtKind::FourStmt(Box::new(d)),
 };
 
 ClosedStmt: StmtKind<'input> = {
@@ -90,6 +91,7 @@ ClosedStmt: StmtKind<'input> = {
         post: c,
         body: Box::new(d)
     },
+    "four" <d:SpannedStmt<ClosedStmt>> => StmtKind::FourStmt(Box::new(d)),
 };
 
 SimpleStmt: StmtKind<'input> = {
@@ -461,6 +463,7 @@ extern {
         "while" => lexer::Tok::While,
         "do" => lexer::Tok::Do,
         "for" => lexer::Tok::For,
+        "four" => lexer::Tok::Four,
         "break" => lexer::Tok::Break,
         "continue" => lexer::Tok::Continue,
         "return" => lexer::Tok::Return,

--- a/compiler/zrc_parser/src/lexer.rs
+++ b/compiler/zrc_parser/src/lexer.rs
@@ -488,6 +488,10 @@ pub enum Tok<'input> {
     #[token("for")]
     #[display("for")]
     For,
+    /// The keyword `four`
+    #[token("four")]
+    #[display("four")]
+    Four,
     /// The keyword `break`
     #[token("break")]
     #[display("break")]
@@ -792,12 +796,13 @@ mod tests {
     /// Tests that all tokens can be properly lexed, and that they all impl
     /// [`Display`] correctly.
     #[test]
+    #[expect(clippy::too_many_lines)]
     fn all_tokens_lex_and_display_correctly() {
         let input = concat!(
             "++ -- + - * / % == != > >= < <= && || ! & | ^ ~ << >> ",
             "= += -= *= /= %= &= |= ^= <<= >>= ; ,",
             " . : :: ? ( ) [ ] { } true false if else while do for break continue return let fn as",
-            r#" struct union enum match sizeof type switch default -> => "str" 7_000 0xF_A"#,
+            r#" struct union enum match sizeof type switch default four -> => "str" 7_000 0xF_A"#,
             " 0b1_0 abc"
         );
         let tokens: Vec<Tok> = vec![
@@ -867,6 +872,7 @@ mod tests {
             Tok::Type,
             Tok::Switch,
             Tok::Default,
+            Tok::Four,
             Tok::SmallArrow,
             Tok::FatArrow,
             Tok::StringLiteral(ZrcString(vec![

--- a/compiler/zrc_typeck/src/tast/stmt.rs
+++ b/compiler/zrc_typeck/src/tast/stmt.rs
@@ -53,6 +53,8 @@ pub enum TypedStmtKind<'input> {
         /// The body of the loop.
         body: Spanned<Vec<TypedStmt<'input>>>,
     },
+    /// `four body`
+    FourStmt(Spanned<Vec<TypedStmt<'input>>>),
     /// `switch`
     SwitchCase {
         /// The value to be switched over (`x` in `switch (x) {}`)
@@ -213,6 +215,17 @@ impl Display for TypedStmtKind<'_> {
                         .join("\n"),
                     if_false
                         .value()
+                        .iter()
+                        .map(|stmt| indent_lines(&stmt.to_string(), "    "))
+                        .collect::<Vec<_>>()
+                        .join("\n")
+                )
+            }
+            Self::FourStmt(body) => {
+                write!(
+                    f,
+                    "four {{\n{}\n}}",
+                    body.value()
                         .iter()
                         .map(|stmt| indent_lines(&stmt.to_string(), "    "))
                         .collect::<Vec<_>>()

--- a/compiler/zrc_typeck/src/typeck/block.rs
+++ b/compiler/zrc_typeck/src/typeck/block.rs
@@ -162,6 +162,9 @@ pub fn type_block<'input, 'gs>(
                                 &return_ability,
                                 stmt_span,
                             ),
+                            StmtKind::FourStmt(body) => {
+                                loops::type_four(&scope, body, &return_ability, stmt_span)
+                            }
 
                             StmtKind::BlockStmt(body) => {
                                 let (typed_body, return_actuality) = type_block(

--- a/compiler/zrc_typeck/src/typeck/block/loops.rs
+++ b/compiler/zrc_typeck/src/typeck/block/loops.rs
@@ -83,6 +83,33 @@ pub fn type_for<'input>(
     )))
 }
 
+/// Type check a four statement.
+pub fn type_four<'input>(
+    scope: &Scope<'input, '_>,
+    body: Box<Stmt<'input>>,
+    return_ability: &BlockReturnAbility<'input>,
+    stmt_span: Span,
+) -> Result<Option<(TypedStmt<'input>, BlockReturnActuality)>, Diagnostic> {
+    let loop_scope = scope.clone();
+
+    let body_as_block = coerce_stmt_into_block(*body);
+
+    let body_as_block_span = body_as_block.span();
+    let (typed_body, body_return_actuality) = type_block(
+        &loop_scope,
+        body_as_block,
+        true,
+        return_ability.clone().demote(),
+    )?;
+
+    Ok(Some((
+        TypedStmt(
+            TypedStmtKind::FourStmt(typed_body.in_span(body_as_block_span)).in_span(stmt_span),
+        ),
+        body_return_actuality,
+    )))
+}
+
 /// Type check a while statement.
 pub fn type_while<'input>(
     scope: &Scope<'input, '_>,

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -5,90 +5,91 @@ Version 0.1.0 (Draft)
 ## Table of Contents
 
 1. [Introduction](#1-introduction)
-   - [About Zirco](#11-about-zirco)
-   - [Design Philosophy](#12-design-philosophy)
-   - [Stability Notice](#13-stability-notice)
+    - [About Zirco](#11-about-zirco)
+    - [Design Philosophy](#12-design-philosophy)
+    - [Stability Notice](#13-stability-notice)
 2. [Lexical Structure](#2-lexical-structure)
-   - [Character Set](#21-character-set)
-   - [Whitespace](#22-whitespace)
-   - [Comments](#23-comments)
-   - [Preprocessor](#24-preprocessor)
-     - [Include Directive](#241-include-directive)
-     - [Pragma Once](#242-pragma-once)
-   - [Keywords](#25-keywords)
-   - [Identifiers](#26-identifiers)
-   - [Literals](#27-literals)
-   - [Operators and Punctuation](#28-operators-and-punctuation)
+    - [Character Set](#21-character-set)
+    - [Whitespace](#22-whitespace)
+    - [Comments](#23-comments)
+    - [Preprocessor](#24-preprocessor)
+        - [Include Directive](#241-include-directive)
+        - [Pragma Once](#242-pragma-once)
+    - [Keywords](#25-keywords)
+    - [Identifiers](#26-identifiers)
+    - [Literals](#27-literals)
+    - [Operators and Punctuation](#28-operators-and-punctuation)
 3. [Type System](#3-type-system)
-   - [Type Overview](#31-type-overview)
-   - [Type Syntax](#32-type-syntax)
-   - [Primitive Types](#33-primitive-types)
-   - [Pointer Types](#34-pointer-types)
-   - [Struct Types](#35-struct-types)
-   - [Union Types](#36-union-types)
-   - [Enum Types](#37-enum-types)
-   - [Type Aliases](#38-type-aliases)
-   - [Type Inference and Implicit Conversions](#39-type-inference-and-implicit-conversions)
+    - [Type Overview](#31-type-overview)
+    - [Type Syntax](#32-type-syntax)
+    - [Primitive Types](#33-primitive-types)
+    - [Pointer Types](#34-pointer-types)
+    - [Struct Types](#35-struct-types)
+    - [Union Types](#36-union-types)
+    - [Enum Types](#37-enum-types)
+    - [Type Aliases](#38-type-aliases)
+    - [Type Inference and Implicit Conversions](#39-type-inference-and-implicit-conversions)
 4. [Expressions](#4-expressions)
-   - [Expression Overview](#41-expression-overview)
-   - [Operator Precedence](#42-operator-precedence)
-   - [Primary Expressions](#43-primary-expressions)
-   - [Arithmetic Expressions](#44-arithmetic-expressions)
-   - [Comparison Expressions](#45-comparison-expressions)
-   - [Logical Expressions](#46-logical-expressions)
-   - [Bitwise Expressions](#47-bitwise-expressions)
-   - [Assignment Expressions](#48-assignment-expressions)
-   - [Pointer Expressions](#49-pointer-expressions)
-   - [Member Access Expressions](#410-member-access-expressions)
-   - [Index Expressions](#411-index-expressions)
-   - [Function Call Expressions](#412-function-call-expressions)
-   - [Cast Expressions](#413-cast-expressions)
-   - [Ternary Conditional Expression](#414-ternary-conditional-expression)
-   - [Sizeof Expressions](#415-sizeof-expressions)
-   - [Comma Expression](#416-comma-expression)
-   - [Increment and Decrement Expressions](#417-increment-and-decrement-expressions)
+    - [Expression Overview](#41-expression-overview)
+    - [Operator Precedence](#42-operator-precedence)
+    - [Primary Expressions](#43-primary-expressions)
+    - [Arithmetic Expressions](#44-arithmetic-expressions)
+    - [Comparison Expressions](#45-comparison-expressions)
+    - [Logical Expressions](#46-logical-expressions)
+    - [Bitwise Expressions](#47-bitwise-expressions)
+    - [Assignment Expressions](#48-assignment-expressions)
+    - [Pointer Expressions](#49-pointer-expressions)
+    - [Member Access Expressions](#410-member-access-expressions)
+    - [Index Expressions](#411-index-expressions)
+    - [Function Call Expressions](#412-function-call-expressions)
+    - [Cast Expressions](#413-cast-expressions)
+    - [Ternary Conditional Expression](#414-ternary-conditional-expression)
+    - [Sizeof Expressions](#415-sizeof-expressions)
+    - [Comma Expression](#416-comma-expression)
+    - [Increment and Decrement Expressions](#417-increment-and-decrement-expressions)
 5. [Statements](#5-statements)
-   - [Statement Overview](#51-statement-overview)
-   - [Expression Statements](#52-expression-statements)
-   - [Empty Statement](#53-empty-statement)
-   - [Block Statements](#54-block-statements)
-   - [Let Declarations (Local Variables)](#55-let-declarations-local-variables)
-   - [If Statements](#56-if-statements)
-   - [While Loops](#57-while-loops)
-   - [Do-While Loops](#58-do-while-loops)
-   - [For Loops](#59-for-loops)
-   - [Break Statement](#510-break-statement)
-   - [Continue Statement](#511-continue-statement)
-   - [Return Statement](#512-return-statement)
-   - [Switch Statement](#513-switch-statement)
-   - [Match Statement](#514-match-statement]
-   - [Optimization Hints](#515-optimization-hints)
-     - [Unreachable Statement](#5151-unreachable-statement)
+    - [Statement Overview](#51-statement-overview)
+    - [Expression Statements](#52-expression-statements)
+    - [Empty Statement](#53-empty-statement)
+    - [Block Statements](#54-block-statements)
+    - [Let Declarations (Local Variables)](#55-let-declarations-local-variables)
+    - [If Statements](#56-if-statements)
+    - [While Loops](#57-while-loops)
+    - [Do-While Loops](#58-do-while-loops)
+    - [For Loops](#59-for-loops)
+    - [Four Loops](#59b-four-loops)
+    - [Break Statement](#510-break-statement)
+    - [Continue Statement](#511-continue-statement)
+    - [Return Statement](#512-return-statement)
+    - [Switch Statement](#513-switch-statement)
+    - [Match Statement](#514-match-statement]
+    - [Optimization Hints](#515-optimization-hints)
+        - [Unreachable Statement](#5151-unreachable-statement)
 6. [Declarations](#6-declarations)
-   - [Declaration Overview](#61-declaration-overview)
-   - [Function Declarations](#62-function-declarations)
-   - [Type Alias Declarations](#63-type-alias-declarations)
-   - [Struct Declarations](#64-struct-declarations)
-   - [Union Declarations](#65-union-declarations)
-   - [Global Let Declarations](#66-global-let-declarations)
+    - [Declaration Overview](#61-declaration-overview)
+    - [Function Declarations](#62-function-declarations)
+    - [Type Alias Declarations](#63-type-alias-declarations)
+    - [Struct Declarations](#64-struct-declarations)
+    - [Union Declarations](#65-union-declarations)
+    - [Global Let Declarations](#66-global-let-declarations)
 7. [Functions](#7-functions)
-   - [Function Declarations](#71-function-declarations)
-   - [Function Parameters](#72-function-parameters)
-   - [Variadic Functions](#73-variadic-functions)
-   - [Function Calls](#74-function-calls)
-   - [External Declarations](#75-external-declarations)
-   - [Return Types](#76-return-types)
-   - [Function Examples](#77-function-examples)
+    - [Function Declarations](#71-function-declarations)
+    - [Function Parameters](#72-function-parameters)
+    - [Variadic Functions](#73-variadic-functions)
+    - [Function Calls](#74-function-calls)
+    - [External Declarations](#75-external-declarations)
+    - [Return Types](#76-return-types)
+    - [Function Examples](#77-function-examples)
 8. [Semantics and Behavior](#8-semantics-and-behavior)
-   - [Memory Model](#81-memory-model)
-   - [Type Compatibility](#82-type-compatibility)
-   - [Evaluation Order](#83-evaluation-order)
-   - [Undefined Behavior](#84-undefined-behavior)
-   - [Scope and Lifetime](#85-scope-and-lifetime)
-   - [Name Resolution](#86-name-resolution)
-   - [Linkage](#87-linkage)
-   - [Program Entry Point](#88-program-entry-point)
-   - [Future Directions](#89-future-directions)
+    - [Memory Model](#81-memory-model)
+    - [Type Compatibility](#82-type-compatibility)
+    - [Evaluation Order](#83-evaluation-order)
+    - [Undefined Behavior](#84-undefined-behavior)
+    - [Scope and Lifetime](#85-scope-and-lifetime)
+    - [Name Resolution](#86-name-resolution)
+    - [Linkage](#87-linkage)
+    - [Program Entry Point](#88-program-entry-point)
+    - [Future Directions](#89-future-directions)
 
 ---
 
@@ -100,10 +101,10 @@ Zirco is a compiled programming language with a strong type system and modern sy
 
 ### 1.2 Design Philosophy
 
-- **Strong Type System**: Zirco aims for an extremely strong runtime type system
-- **Modern Syntax**: Combines the familiarity of C with modern language design
-- **Compiled**: Compiles to native code via LLVM
-- **Systems Programming**: Suitable for low-level systems programming tasks
+-   **Strong Type System**: Zirco aims for an extremely strong runtime type system
+-   **Modern Syntax**: Combines the familiarity of C with modern language design
+-   **Compiled**: Compiles to native code via LLVM
+-   **Systems Programming**: Suitable for low-level systems programming tasks
 
 ### 1.3 Stability Notice
 
@@ -120,10 +121,11 @@ Zirco source files are UTF-8 encoded text files. The language uses ASCII for key
 ### 2.2 Whitespace
 
 Whitespace characters include:
-- Space (U+0020)
-- Tab (U+0009)
-- Newline (U+000A)
-- Carriage return (U+000D)
+
+-   Space (U+0020)
+-   Tab (U+0009)
+-   Newline (U+000A)
+-   Carriage return (U+000D)
 
 Whitespace is used to separate tokens but is otherwise ignored.
 
@@ -152,8 +154,8 @@ The `#include` directive inserts the contents of another file:
 #include <system/header.zr>
 ```
 
-- Files enclosed in double quotes (`"file.zr"`) are searched relative to the current file's directory
-- Files enclosed in angle brackets (`<file.zr>`) follow the same search path as double quotes
+-   Files enclosed in double quotes (`"file.zr"`) are searched relative to the current file's directory
+-   Files enclosed in angle brackets (`<file.zr>`) follow the same search path as double quotes
 
 #### 2.4.2 Pragma Once
 
@@ -170,6 +172,7 @@ When a file with `#pragma once` is included, the preprocessor remembers it and s
 **Example**:
 
 **types.zr**:
+
 ```zirco
 #pragma once
 
@@ -180,6 +183,7 @@ struct Point {
 ```
 
 **main.zr**:
+
 ```zirco
 #include "types.zr"
 #include "types.zr"  // This include will be skipped
@@ -197,7 +201,7 @@ The following identifiers are reserved keywords and cannot be used as variable o
 as          break       continue    default     do
 else        false       fn          for         if
 let         return      sizeof      struct      switch
-true        type        union       while
+true        type        union       while       four
 ```
 
 ### 2.6 Identifiers
@@ -205,16 +209,19 @@ true        type        union       while
 Identifiers are used to name variables, functions, types, and other program entities.
 
 **Syntax**:
+
 ```
 identifier ::= [a-zA-Z_][a-zA-Z0-9_]*
 ```
 
 **Rules**:
-- Must start with a letter (uppercase or lowercase) or underscore
-- May contain letters, digits, and underscores
-- Case-sensitive
+
+-   Must start with a letter (uppercase or lowercase) or underscore
+-   May contain letters, digits, and underscores
+-   Case-sensitive
 
 **Examples**:
+
 ```zirco
 x
 my_variable
@@ -230,6 +237,7 @@ value123
 Integer literals can be written in decimal, hexadecimal, or binary notation:
 
 **Decimal**: `[0-9][0-9_]*`
+
 ```zirco
 42
 1000
@@ -237,6 +245,7 @@ Integer literals can be written in decimal, hexadecimal, or binary notation:
 ```
 
 **Hexadecimal**: `0x[0-9a-fA-F_]+`
+
 ```zirco
 0xFF
 0x1A2B
@@ -244,6 +253,7 @@ Integer literals can be written in decimal, hexadecimal, or binary notation:
 ```
 
 **Binary**: `0b[01_]+`
+
 ```zirco
 0b1010
 0b1111_0000
@@ -281,11 +291,12 @@ String literals are enclosed in double quotes and may contain escape sequences:
 ```
 
 **Supported Escape Sequences**:
-- `\n` - Newline
-- `\r` - Carriage return
-- `\t` - Tab
-- `\\` - Backslash
-- `\"` - Double quote
+
+-   `\n` - Newline
+-   `\r` - Carriage return
+-   `\t` - Tab
+-   `\\` - Backslash
+-   `\"` - Double quote
 
 String literals must be closed on the same line (multi-line strings are not supported).
 
@@ -308,37 +319,44 @@ Character literals support the same escape sequences as string literals.
 Zirco uses the following operators and punctuation:
 
 **Arithmetic Operators**:
+
 ```
 +   -   *   /   %   ++  --
 ```
 
 **Comparison Operators**:
+
 ```
 ==  !=  <   <=  >   >=
 ```
 
 **Logical Operators**:
+
 ```
 &&  ||  !
 ```
 
 **Bitwise Operators**:
+
 ```
 &   |   ^   ~   <<  >>
 ```
 
 **Assignment Operators**:
+
 ```
 =   +=  -=  *=  /=  %=
 &=  |=  ^=  <<=  >>=
 ```
 
 **Other Operators**:
+
 ```
 .   ->  ::  ?   :   as
 ```
 
 **Delimiters**:
+
 ```
 (   )   {   }   [   ]
 ,   ;   =>  ...
@@ -369,25 +387,29 @@ type ::= identifier
 Zirco has the following built-in primitive types that are explicitly defined by the compiler:
 
 **Signed Integers**:
-- `i8` - 8-bit signed integer
-- `i16` - 16-bit signed integer
-- `i32` - 32-bit signed integer
-- `i64` - 64-bit signed integer
-- `isize` - Pointer-sized signed integer
+
+-   `i8` - 8-bit signed integer
+-   `i16` - 16-bit signed integer
+-   `i32` - 32-bit signed integer
+-   `i64` - 64-bit signed integer
+-   `isize` - Pointer-sized signed integer
 
 **Unsigned Integers**:
-- `u8` - 8-bit unsigned integer
-- `u16` - 16-bit unsigned integer
-- `u32` - 32-bit unsigned integer
-- `u64` - 64-bit unsigned integer
-- `usize` - Pointer-sized unsigned integer
+
+-   `u8` - 8-bit unsigned integer
+-   `u16` - 16-bit unsigned integer
+-   `u32` - 32-bit unsigned integer
+-   `u64` - 64-bit unsigned integer
+-   `usize` - Pointer-sized unsigned integer
 
 **Boolean**:
-- `bool` - Boolean type (true or false)
+
+-   `bool` - Boolean type (true or false)
 
 **Unit/Void Type**:
-- `struct {}` - Empty struct, used as the unit/void type
-- `*struct {}` - Pointer to empty struct, used as a void pointer (analogous to `void*` in C)
+
+-   `struct {}` - Empty struct, used as the unit/void type
+-   `*struct {}` - Pointer to empty struct, used as a void pointer (analogous to `void*` in C)
 
 ### 3.4 Pointer Types
 
@@ -406,26 +428,31 @@ Pointer types are formed by prefixing a type with `*`:
 Structs are product types that group named fields together:
 
 **Inline Struct Syntax**:
+
 ```zirco
 struct { x: i32, y: i32 }
 ```
 
 **Named Struct Declaration**:
+
 ```zirco
 struct Point { x: i32, y: i32 }
 ```
 
 The second form is syntactic sugar for:
+
 ```zirco
 type Point = struct { x: i32, y: i32 };
 ```
 
 **Rules**:
-- Field names must be unique within a struct
-- Fields are accessed using the `.` operator
-- Structs can be nested
+
+-   Field names must be unique within a struct
+-   Fields are accessed using the `.` operator
+-   Structs can be nested
 
 **Example**:
+
 ```zirco
 struct Person {
     name: *u8,
@@ -443,24 +470,28 @@ struct Company {
 Unions are sum types where a value can be one of several different types:
 
 **Inline Union Syntax**:
+
 ```zirco
 union { i: i32, f: f32 }
 ```
 
 **Named Union Declaration**:
+
 ```zirco
 union Value { i: i32, f: f32 }
 ```
 
 The second form is syntactic sugar for:
+
 ```zirco
 type Value = union { i: i32, f: f32 };
 ```
 
 **Rules**:
-- Only one field is active at a time
-- Fields are accessed using the `.` operator
-- Reading an inactive field is undefined behavior
+
+-   Only one field is active at a time
+-   Fields are accessed using the `.` operator
+-   Reading an inactive field is undefined behavior
 
 ### 3.7 Enum Types
 
@@ -468,6 +499,7 @@ Enums are tagged unions, or sum types where a value must be _verified_ to be one
 several types before use.
 
 **Union Declaration:**
+
 ```zirco
 union MyUnion {
    // name each variant here...
@@ -504,12 +536,12 @@ Zirco allows the following implicit type conversions:
 
 1. **Pointer to Void Pointer**: Any pointer type `*T` can be implicitly converted to a void pointer `*struct {}`. This is useful for generic pointer handling.
 
-   ```zirco
-   fn takes_void_ptr(ptr: *struct {});
-   
-   let x: i32;
-   takes_void_ptr(&x);  // *i32 implicitly converts to *struct {}
-   ```
+    ```zirco
+    fn takes_void_ptr(ptr: *struct {});
+
+    let x: i32;
+    takes_void_ptr(&x);  // *i32 implicitly converts to *struct {}
+    ```
 
 2. **Untyped Integer Literals**: Integer literals without a type suffix can be implicitly converted to any integer type when used in contexts where the target type is known (implementation-defined behavior).
 
@@ -527,24 +559,24 @@ Expressions are combinations of values, variables, operators, and function calls
 
 Operators are listed from highest to lowest precedence:
 
-| Precedence | Operators | Description | Associativity |
-|------------|-----------|-------------|---------------|
-| 1 | `x()` `x[]` `x.y` `x->y` `x++` `x--` | Function call, array index, member access, postfix increment/decrement | Left-to-right |
-| 2 | `!x` `-x` `~x` `&x` `*x` `++x` `--x` | Unary operators, prefix increment/decrement | Right-to-left |
-| 3 | `as` | Type cast | Left-to-right |
-| 4 | `*` `/` `%` | Multiplication, division, modulo | Left-to-right |
-| 5 | `+` `-` | Addition, subtraction | Left-to-right |
-| 6 | `<<` `>>` | Bitwise shift | Left-to-right |
-| 7 | `<` `<=` `>` `>=` | Comparison | Left-to-right |
-| 8 | `==` `!=` | Equality | Left-to-right |
-| 9 | `&` | Bitwise AND | Left-to-right |
-| 10 | `^` | Bitwise XOR | Left-to-right |
-| 11 | `\|` | Bitwise OR | Left-to-right |
-| 12 | `&&` | Logical AND | Left-to-right |
-| 13 | `\|\|` | Logical OR | Left-to-right |
-| 14 | `? :` | Ternary conditional | Right-to-left |
-| 15 | `=` `+=` `-=` `*=` `/=` `%=` `&=` `\|=` `^=` `<<=` `>>=` | Assignment | Right-to-left |
-| 16 | `,` | Comma | Left-to-right |
+| Precedence | Operators                                                | Description                                                            | Associativity |
+| ---------- | -------------------------------------------------------- | ---------------------------------------------------------------------- | ------------- |
+| 1          | `x()` `x[]` `x.y` `x->y` `x++` `x--`                     | Function call, array index, member access, postfix increment/decrement | Left-to-right |
+| 2          | `!x` `-x` `~x` `&x` `*x` `++x` `--x`                     | Unary operators, prefix increment/decrement                            | Right-to-left |
+| 3          | `as`                                                     | Type cast                                                              | Left-to-right |
+| 4          | `*` `/` `%`                                              | Multiplication, division, modulo                                       | Left-to-right |
+| 5          | `+` `-`                                                  | Addition, subtraction                                                  | Left-to-right |
+| 6          | `<<` `>>`                                                | Bitwise shift                                                          | Left-to-right |
+| 7          | `<` `<=` `>` `>=`                                        | Comparison                                                             | Left-to-right |
+| 8          | `==` `!=`                                                | Equality                                                               | Left-to-right |
+| 9          | `&`                                                      | Bitwise AND                                                            | Left-to-right |
+| 10         | `^`                                                      | Bitwise XOR                                                            | Left-to-right |
+| 11         | `\|`                                                     | Bitwise OR                                                             | Left-to-right |
+| 12         | `&&`                                                     | Logical AND                                                            | Left-to-right |
+| 13         | `\|\|`                                                   | Logical OR                                                             | Left-to-right |
+| 14         | `? :`                                                    | Ternary conditional                                                    | Right-to-left |
+| 15         | `=` `+=` `-=` `*=` `/=` `%=` `&=` `\|=` `^=` `<<=` `>>=` | Assignment                                                             | Right-to-left |
+| 16         | `,`                                                      | Comma                                                                  | Left-to-right |
 
 ### 4.3 Primary Expressions
 
@@ -572,13 +604,15 @@ Expressions can be wrapped in parentheses to control evaluation order:
 ### 4.4 Arithmetic Expressions
 
 **Binary Arithmetic Operators**:
-- `+` Addition
-- `-` Subtraction
-- `*` Multiplication
-- `/` Division
-- `%` Modulo
+
+-   `+` Addition
+-   `-` Subtraction
+-   `*` Multiplication
+-   `/` Division
+-   `%` Modulo
 
 **Example**:
+
 ```zirco
 let x = 10 + 5;
 let y = 20 * 3 - 4;
@@ -587,7 +621,8 @@ let remainder = 17 % 5;
 ```
 
 **Unary Arithmetic Operator**:
-- `-` Negation
+
+-   `-` Negation
 
 ```zirco
 let x = -5;
@@ -597,16 +632,19 @@ let y = -(10 + 3);
 ### 4.5 Comparison Expressions
 
 **Comparison Operators**:
-- `>` Greater than
-- `>=` Greater than or equal
-- `<` Less than
-- `<=` Less than or equal
+
+-   `>` Greater than
+-   `>=` Greater than or equal
+-   `<` Less than
+-   `<=` Less than or equal
 
 **Equality Operators**:
-- `==` Equal to
-- `!=` Not equal to
+
+-   `==` Equal to
+-   `!=` Not equal to
 
 **Example**:
+
 ```zirco
 let a = 5 > 3;      // true
 let b = 10 <= 10;   // true
@@ -615,17 +653,20 @@ let d = 5 != 3;     // true
 ```
 
 **Rules**:
-- Operands must be of the same type
-- Result is a boolean value
+
+-   Operands must be of the same type
+-   Result is a boolean value
 
 ### 4.6 Logical Expressions
 
 **Logical Operators**:
-- `&&` Logical AND
-- `||` Logical OR
-- `!` Logical NOT (unary)
+
+-   `&&` Logical AND
+-   `||` Logical OR
+-   `!` Logical NOT (unary)
 
 **Example**:
+
 ```zirco
 let a = true && false;   // false
 let b = true || false;   // true
@@ -633,22 +674,26 @@ let c = !true;           // false
 ```
 
 **Rules**:
-- Operands must be boolean values
-- `&&` and `||` use short-circuit evaluation
+
+-   Operands must be boolean values
+-   `&&` and `||` use short-circuit evaluation
 
 ### 4.7 Bitwise Expressions
 
 **Binary Bitwise Operators**:
-- `&` Bitwise AND
-- `|` Bitwise OR
-- `^` Bitwise XOR
-- `<<` Left shift
-- `>>` Right shift
+
+-   `&` Bitwise AND
+-   `|` Bitwise OR
+-   `^` Bitwise XOR
+-   `<<` Left shift
+-   `>>` Right shift
 
 **Unary Bitwise Operator**:
-- `~` Bitwise NOT
+
+-   `~` Bitwise NOT
 
 **Example**:
+
 ```zirco
 let a = 0b1010 & 0b1100;   // 0b1000
 let b = 0b1010 | 0b1100;   // 0b1110
@@ -661,11 +706,13 @@ let f = ~0b1010;           // bitwise negation
 ### 4.8 Assignment Expressions
 
 **Simple Assignment**:
+
 ```zirco
 x = 5;
 ```
 
 **Compound Assignment Operators**:
+
 ```zirco
 x += 5;    // x = x + 5
 x -= 3;    // x = x - 3
@@ -680,9 +727,10 @@ x >>= 1;   // x = x >> 1
 ```
 
 **Rules**:
-- Left side must be an lvalue (assignable location)
-- Assignment is an expression and returns the assigned value
-- Assignment is right-associative
+
+-   Left side must be an lvalue (assignable location)
+-   Assignment is an expression and returns the assigned value
+-   Assignment is right-associative
 
 ### 4.9 Pointer Expressions
 
@@ -739,8 +787,9 @@ arr[5] = 42;
 ```
 
 **Rules**:
-- The index must be of type `usize`
-- Indexing is equivalent to pointer arithmetic and dereferencing
+
+-   The index must be of type `usize`
+-   Indexing is equivalent to pointer arithmetic and dereferencing
 
 ### 4.12 Function Call Expressions
 
@@ -752,8 +801,9 @@ let result = add(5, 3);
 ```
 
 **Rules**:
-- Arguments are evaluated left-to-right (evaluation order is defined)
-- Number and types of arguments must match the function signature
+
+-   Arguments are evaluated left-to-right (evaluation order is defined)
+-   Number and types of arguments must match the function signature
 
 ### 4.13 Cast Expressions
 
@@ -778,21 +828,24 @@ let sign = x >= 0 ? 1 : -1;
 **Syntax**: `condition ? true_expr : false_expr`
 
 **Rules**:
-- Condition must be a boolean expression
-- Both branches must have compatible types
-- Only the selected branch is evaluated
+
+-   Condition must be a boolean expression
+-   Both branches must have compatible types
+-   Only the selected branch is evaluated
 
 ### 4.15 Sizeof Expressions
 
 The `sizeof` operator returns the size of a type or expression:
 
 **Sizeof Type**:
+
 ```zirco
 let size = sizeof i32;
 let ptr_size = sizeof *u8;
 ```
 
 **Sizeof Expression**:
+
 ```zirco
 let x = 42;
 let size = sizeof(x);
@@ -807,23 +860,27 @@ let x = (a = 5, b = 10, a + b);  // x is 15
 ```
 
 **Rules**:
-- Expressions are evaluated left-to-right
-- Result is the value of the rightmost expression
-- Primarily used for side effects
+
+-   Expressions are evaluated left-to-right
+-   Result is the value of the rightmost expression
+-   Primarily used for side effects
 
 ### 4.17 Increment and Decrement Expressions
 
 Zirco supports both prefix and postfix increment and decrement operators for integer types.
 
 **Postfix Operators**:
-- `x++` - Postfix increment: returns the current value of `x`, then increments `x`
-- `x--` - Postfix decrement: returns the current value of `x`, then decrements `x`
+
+-   `x++` - Postfix increment: returns the current value of `x`, then increments `x`
+-   `x--` - Postfix decrement: returns the current value of `x`, then decrements `x`
 
 **Prefix Operators**:
-- `++x` - Prefix increment: increments `x`, then returns the new value
-- `--x` - Prefix decrement: decrements `x`, then returns the new value
+
+-   `++x` - Prefix increment: increments `x`, then returns the new value
+-   `--x` - Prefix decrement: decrements `x`, then returns the new value
 
 **Example**:
+
 ```zirco
 let x = 5;
 
@@ -839,15 +896,17 @@ for (let i = 0; i < 10; i++) {
 ```
 
 **Rules**:
-- Operand must be an integer lvalue (a modifiable variable)
-- Cannot be used on constants or expressions
-- Prefix operators have unary precedence (level 2)
-- Postfix operators have the highest precedence (level 1)
-- The value is incremented or decremented by 1
+
+-   Operand must be an integer lvalue (a modifiable variable)
+-   Cannot be used on constants or expressions
+-   Prefix operators have unary precedence (level 2)
+-   Postfix operators have the highest precedence (level 1)
+-   The value is incremented or decremented by 1
 
 **Parsing Disambiguation**:
-- `a+++b` is parsed as `(a++) + b` (maximal munch rule)
-- Use spacing to disambiguate: `a+ ++b` parses as `a + (++b)`
+
+-   `a+++b` is parsed as `(a++) + b` (maximal munch rule)
+-   Use spacing to disambiguate: `a+ ++b` parses as `a + (++b)`
 
 ---
 
@@ -888,15 +947,17 @@ A sequence of statements enclosed in braces:
 ```
 
 **Rules**:
-- Variables declared in a block are scoped to that block
-- Blocks can be nested
-- Blocks can appear anywhere a statement is expected
+
+-   Variables declared in a block are scoped to that block
+-   Blocks can be nested
+-   Blocks can appear anywhere a statement is expected
 
 ### 5.5 Let Declarations (Local Variables)
 
 The `let` keyword declares local variables:
 
 **Basic Syntax**:
+
 ```zirco
 let x;              // declare without initialization
 let y: i32;         // declare with type
@@ -905,22 +966,25 @@ let w: i32 = 100;   // declare with type and initializer
 ```
 
 **Multiple Declarations**:
+
 ```zirco
 let a = 1, b = 2, c = 3;
 let x: i32, y: i32, z: i32;
 ```
 
 **Rules**:
-- Variables must be declared before use
-- Multiple variables can be declared in a single statement
-- Type can be inferred from initializer (implementation-defined)
-- Uninitialized variables have indeterminate values
+
+-   Variables must be declared before use
+-   Multiple variables can be declared in a single statement
+-   Type can be inferred from initializer (implementation-defined)
+-   Uninitialized variables have indeterminate values
 
 ### 5.6 If Statements
 
 Conditional execution based on a boolean expression:
 
 **Basic If**:
+
 ```zirco
 if (x > 0) {
     printf("positive\n");
@@ -928,6 +992,7 @@ if (x > 0) {
 ```
 
 **If-Else**:
+
 ```zirco
 if (x > 0) {
     printf("positive\n");
@@ -937,6 +1002,7 @@ if (x > 0) {
 ```
 
 **If-Else If-Else Chain**:
+
 ```zirco
 if (x > 0) {
     printf("positive\n");
@@ -948,10 +1014,11 @@ if (x > 0) {
 ```
 
 **Rules**:
-- Condition must be enclosed in parentheses
-- Condition must be a boolean expression
-- Braces are optional for single statements but recommended
-- Dangling else attaches to the nearest if
+
+-   Condition must be enclosed in parentheses
+-   Condition must be a boolean expression
+-   Braces are optional for single statements but recommended
+-   Dangling else attaches to the nearest if
 
 ### 5.7 While Loops
 
@@ -965,9 +1032,10 @@ while (i < 10) {
 ```
 
 **Rules**:
-- Condition is evaluated before each iteration
-- Loop body may execute zero or more times
-- Condition must be enclosed in parentheses
+
+-   Condition is evaluated before each iteration
+-   Loop body may execute zero or more times
+-   Condition must be enclosed in parentheses
 
 ### 5.8 Do-While Loops
 
@@ -981,9 +1049,10 @@ do {
 ```
 
 **Rules**:
-- Loop body executes at least once
-- Condition is evaluated after each iteration
-- Must end with a semicolon after the condition
+
+-   Loop body executes at least once
+-   Condition is evaluated after each iteration
+-   Must end with a semicolon after the condition
 
 ### 5.9 For Loops
 
@@ -996,6 +1065,7 @@ for (let i = 0; i < 10; i = i + 1) {
 ```
 
 **Alternative Forms**:
+
 ```zirco
 for (; i < 10; i = i + 1) {  // no initialization
     // ...
@@ -1017,11 +1087,29 @@ for (;;) {  // infinite loop
 **Syntax**: `for (init; condition; post) body`
 
 **Rules**:
-- Initialization runs once before the loop starts
-- Condition is checked before each iteration
-- Post-expression runs after each iteration
-- All three parts are optional
-- Variables declared in init are scoped to the loop
+
+-   Initialization runs once before the loop starts
+-   Condition is checked before each iteration
+-   Post-expression runs after each iteration
+-   All three parts are optional
+-   Variables declared in init are scoped to the loop
+
+### 5.9b Four Loops
+
+A specialized loop for iterating four times, and exactly four times:
+
+```zirco
+four printf("This will print four times.\n");
+four {
+    printf("This will print four times.\n");
+}
+```
+
+**Rules**:
+
+-   The loop body executes exactly four times
+-   `break` and `continue` statements may be used within the loop to alter control flow
+-   No loop variable is provided; use an external counter if needed
 
 ### 5.10 Break Statement
 
@@ -1053,20 +1141,23 @@ for (let i = 0; i < 10; i = i + 1) {
 Return from a function:
 
 **Return Void**:
+
 ```zirco
 return;
 ```
 
 **Return Value**:
+
 ```zirco
 return 42;
 return x + y;
 ```
 
 **Rules**:
-- Return type must match function signature
-- Void functions use `return;` or omit return at the end
-- Functions with return types must return a value on all paths
+
+-   Return type must match function signature
+-   Void functions use `return;` or omit return at the end
+-   Functions with return types must return a value on all paths
 
 ### 5.13 Switch Statement
 
@@ -1085,11 +1176,12 @@ switch (x) {
 ```
 
 **Rules**:
-- Each case uses `=>` syntax (fat arrow)
-- Cases can match expressions, not just constants
-- `default` case handles all unmatched values
-- No fall-through between cases
-- Each case body is a single statement (use blocks for multiple statements)
+
+-   Each case uses `=>` syntax (fat arrow)
+-   Cases can match expressions, not just constants
+-   `default` case handles all unmatched values
+-   No fall-through between cases
+-   Each case body is a single statement (use blocks for multiple statements)
 
 ### 5.14 Match Statement
 
@@ -1105,10 +1197,11 @@ match (x) {
 ```
 
 **Rules**:
-- Each case uses `=>` syntax (fat arrow)
-- No fall-through between cases
-- Each case body is a single statement (use blocks for multiple statements)
-- There must be exactly one case per variant
+
+-   Each case uses `=>` syntax (fat arrow)
+-   No fall-through between cases
+-   Each case body is a single statement (use blocks for multiple statements)
+-   There must be exactly one case per variant
 
 ### 5.15 Optimization Hints
 
@@ -1168,6 +1261,7 @@ struct Point {
 ```
 
 This is equivalent to:
+
 ```zirco
 type Point = struct { x: i32, y: i32 };
 ```
@@ -1185,6 +1279,7 @@ union Value {
 ```
 
 This is equivalent to:
+
 ```zirco
 type Value = union { i: i32, f: f32, b: u8 };
 ```
@@ -1202,27 +1297,31 @@ let VERSION: i8 = 1i8;
 **Syntax**: `let name: type = initializer;`
 
 **Rules**:
-- Global variables must be declared at file scope (not inside functions)
-- Type annotation is required (no type inference for globals)
-- Initializer must be a constant expression (literals only)
-- Supported constant expressions:
-  - Number literals: `42`, `0xFF`, `0b1010`, `42i8`
-  - Boolean literals: `true`, `false`
-  - Character literals: `'a'`, `'\n'`
-  - String literals: `"hello"`
-- Variables without initializers are zero-initialized
+
+-   Global variables must be declared at file scope (not inside functions)
+-   Type annotation is required (no type inference for globals)
+-   Initializer must be a constant expression (literals only)
+-   Supported constant expressions:
+    -   Number literals: `42`, `0xFF`, `0b1010`, `42i8`
+    -   Boolean literals: `true`, `false`
+    -   Character literals: `'a'`, `'\n'`
+    -   String literals: `"hello"`
+-   Variables without initializers are zero-initialized
 
 **Multiple Declarations**:
+
 ```zirco
 let x: i32 = 10, y: i32 = 20, z: i32 = 30;
 ```
 
 **Zero-Initialized Variable**:
+
 ```zirco
 let counter: i32;  // initialized to 0
 ```
 
 **Example with Usage**:
+
 ```zirco
 let MAX_RETRIES: i32 = 5;
 let error_count: i32;
@@ -1237,10 +1336,11 @@ fn should_retry() -> bool {
 ```
 
 **Restrictions**:
-- Initializers cannot reference other variables
-- Initializers cannot call functions
-- Initializers cannot use arithmetic or other operations
-- Global variables are always mutable
+
+-   Initializers cannot reference other variables
+-   Initializers cannot call functions
+-   Initializers cannot use arithmetic or other operations
+-   Global variables are always mutable
 
 ---
 
@@ -1249,6 +1349,7 @@ fn should_retry() -> bool {
 ### 7.1 Function Declarations
 
 **Basic Function**:
+
 ```zirco
 fn add(a: i32, b: i32) -> i32 {
     return a + b;
@@ -1256,6 +1357,7 @@ fn add(a: i32, b: i32) -> i32 {
 ```
 
 **Void Function** (no return type):
+
 ```zirco
 fn print_hello() {
     printf("Hello!\n");
@@ -1275,6 +1377,7 @@ fn multiply(x: i32, y: i32) -> i32 {
 ```
 
 **Multiple Parameters**:
+
 ```zirco
 fn complex_function(a: i32, b: *u8, c: Point) -> i32 {
     // ...
@@ -1282,10 +1385,11 @@ fn complex_function(a: i32, b: *u8, c: Point) -> i32 {
 ```
 
 **Rules**:
-- Each parameter must have a type annotation
-- Parameters are separated by commas
-- Parameters are local to the function
-- Trailing comma is allowed
+
+-   Each parameter must have a type annotation
+-   Parameters are separated by commas
+-   Parameters are local to the function
+-   Trailing comma is allowed
 
 ### 7.3 Variadic Functions
 
@@ -1296,9 +1400,10 @@ fn printf(format: *u8, ...) -> i32;
 ```
 
 **Rules**:
-- `...` must be the last parameter
-- Must have at least one non-variadic parameter
-- Accessing variadic arguments is implementation-defined
+
+-   `...` must be the last parameter
+-   Must have at least one non-variadic parameter
+-   Accessing variadic arguments is implementation-defined
 
 ### 7.4 Function Calls
 
@@ -1320,13 +1425,15 @@ fn malloc(size: u64) -> *u8;
 These are typically used to interface with C libraries.
 
 **Rules**:
-- External declarations end with a semicolon instead of a body
-- Must match the actual external function signature
-- No body is provided
+
+-   External declarations end with a semicolon instead of a body
+-   Must match the actual external function signature
+-   No body is provided
 
 ### 7.6 Return Types
 
 **Explicit Return Type**:
+
 ```zirco
 fn get_value() -> i32 {
     return 42;
@@ -1334,6 +1441,7 @@ fn get_value() -> i32 {
 ```
 
 **Void Return** (omit `-> type`):
+
 ```zirco
 fn do_something() {
     printf("done\n");
@@ -1343,6 +1451,7 @@ fn do_something() {
 ### 7.7 Function Examples
 
 **Simple Function**:
+
 ```zirco
 fn square(x: i32) -> i32 {
     return x * x;
@@ -1350,6 +1459,7 @@ fn square(x: i32) -> i32 {
 ```
 
 **Multiple Returns**:
+
 ```zirco
 fn absolute(x: i32) -> i32 {
     if (x < 0) {
@@ -1361,6 +1471,7 @@ fn absolute(x: i32) -> i32 {
 ```
 
 **Struct Return**:
+
 ```zirco
 fn make_point(x: i32, y: i32) -> Point {
     let p: Point;
@@ -1378,56 +1489,59 @@ fn make_point(x: i32, y: i32) -> Point {
 
 Zirco follows a C-like memory model:
 
-- Variables are stored in memory locations
-- Pointers hold memory addresses
-- Memory can be accessed through pointers
-- Memory safety is not guaranteed by the language
+-   Variables are stored in memory locations
+-   Pointers hold memory addresses
+-   Memory can be accessed through pointers
+-   Memory safety is not guaranteed by the language
 
 ### 8.2 Type Compatibility
 
-- Types must match exactly in most contexts
-- Implicit conversions are not performed
-- Explicit casts using `as` are required to convert between types
+-   Types must match exactly in most contexts
+-   Implicit conversions are not performed
+-   Explicit casts using `as` are required to convert between types
 
 ### 8.3 Evaluation Order
 
 **Expression Evaluation**:
-- Function arguments are evaluated left-to-right
-- Most other evaluation orders are implementation-defined
+
+-   Function arguments are evaluated left-to-right
+-   Most other evaluation orders are implementation-defined
 
 **Short-Circuit Evaluation**:
-- `&&` and `||` use short-circuit evaluation
-- The right operand is not evaluated if the result is determined by the left operand
+
+-   `&&` and `||` use short-circuit evaluation
+-   The right operand is not evaluated if the result is determined by the left operand
 
 ### 8.4 Undefined Behavior
 
 The following behaviors are undefined:
 
-- Reading uninitialized variables
-- Dereferencing invalid pointers
-- Accessing arrays out of bounds
-- Reading an inactive union field
-- Division by zero
-- Integer overflow (behavior is implementation-defined)
+-   Reading uninitialized variables
+-   Dereferencing invalid pointers
+-   Accessing arrays out of bounds
+-   Reading an inactive union field
+-   Division by zero
+-   Integer overflow (behavior is implementation-defined)
 
 ### 8.5 Scope and Lifetime
 
 **Scope Rules**:
-- Variables are scoped to the block in which they are declared
-- Function parameters are scoped to the function body
-- Global declarations have file scope
+
+-   Variables are scoped to the block in which they are declared
+-   Function parameters are scoped to the function body
+-   Global declarations have file scope
 
 ### 8.6 Name Resolution
 
-- Names are resolved in the innermost scope first
-- Outer scopes are searched if a name is not found in the current scope
-- Global names can be accessed from any scope unless shadowed
+-   Names are resolved in the innermost scope first
+-   Outer scopes are searched if a name is not found in the current scope
+-   Global names can be accessed from any scope unless shadowed
 
 ### 8.7 Linkage
 
-- Functions can be declared as external to link with C libraries
-- The linker combines compiled object files into executables
-- Linking behavior follows the platform's standard
+-   Functions can be declared as external to link with C libraries
+-   The linker combines compiled object files into executables
+-   Linking behavior follows the platform's standard
 
 ### 8.8 Program Entry Point
 
@@ -1445,13 +1559,13 @@ The signature of `main` follows C conventions and is compatible with what LLVM a
 
 The following features are planned or under consideration:
 
-- Arrays with first-class syntax
-- Generics/parametric polymorphism
-- Pattern matching
-- Modules and namespaces
-- Enhanced type inference
-- Traits/interfaces
-- Enhanced safety features
+-   Arrays with first-class syntax
+-   Generics/parametric polymorphism
+-   Pattern matching
+-   Modules and namespaces
+-   Enhanced type inference
+-   Traits/interfaces
+-   Enhanced safety features
 
 ---
 
@@ -1462,10 +1576,10 @@ This section provides a high-level grammar summary. For complete details, refer 
 ### A.1 Lexical Grammar
 
 ```
-keyword ::= "as" | "break" | "continue" | "default" | "do" | "else" 
-          | "false" | "fn" | "for" | "if" | "let" | "return" 
-          | "sizeof" | "struct" | "switch" | "true" | "type" 
-          | "union" | "while"
+keyword ::= "as" | "break" | "continue" | "default" | "do" | "else"
+          | "false" | "fn" | "for" | "if" | "let" | "return"
+          | "sizeof" | "struct" | "switch" | "true" | "type"
+          | "union" | "while" | "four"
 
 identifier ::= [a-zA-Z_][a-zA-Z0-9_]*
 
@@ -1510,6 +1624,7 @@ stmt ::= expr ";"
        | "while" "(" expr ")" stmt
        | "do" stmt "while" "(" expr ")" ";"
        | "for" "(" for_init? ";" expr? ";" expr? ")" stmt
+       | "four" stmt
        | "switch" "(" expr ")" "{" switch_case* "}"
        | "break" ";"
        | "continue" ";"
@@ -1621,19 +1736,19 @@ fn print_numbers(n: i32) {
 
 ## Appendix E: Terminology
 
-- **AST**: Abstract Syntax Tree - the tree representation of source code structure
-- **TAST**: Typed Abstract Syntax Tree - AST with type information
-- **LLVM**: Low Level Virtual Machine - the compiler backend used by Zirco
-- **lvalue**: An expression that refers to a memory location
-- **rvalue**: An expression that produces a value
-- **Short-circuit evaluation**: Evaluation strategy where the second operand is not evaluated if the result is determined by the first
+-   **AST**: Abstract Syntax Tree - the tree representation of source code structure
+-   **TAST**: Typed Abstract Syntax Tree - AST with type information
+-   **LLVM**: Low Level Virtual Machine - the compiler backend used by Zirco
+-   **lvalue**: An expression that refers to a memory location
+-   **rvalue**: An expression that produces a value
+-   **Short-circuit evaluation**: Evaluation strategy where the second operand is not evaluated if the result is determined by the first
 
 ---
 
 ## Appendix F: Document History
 
-- **Version 0.1.0 (Draft)**: Initial language specification
+-   **Version 0.1.0 (Draft)**: Initial language specification
 
 ---
 
-*This specification is subject to change as Zirco evolves. Last updated: 2025*
+_This specification is subject to change as Zirco evolves. Last updated: 2025_

--- a/examples/four_loops/Makefile
+++ b/examples/four_loops/Makefile
@@ -1,0 +1,1 @@
+include ../common.mk

--- a/examples/four_loops/main.zr
+++ b/examples/four_loops/main.zr
@@ -1,0 +1,7 @@
+#include <stdio.zh>
+
+fn main() -> i32 {
+    four printf("Hello, World!\n");
+
+    return 0;
+}

--- a/examples/four_loops/test/stdout.txt
+++ b/examples/four_loops/test/stdout.txt
@@ -1,0 +1,4 @@
+Hello, World!
+Hello, World!
+Hello, World!
+Hello, World!


### PR DESCRIPTION
This PR adds `four` statements to the Zirco programming language.

## What are `four` statements?
Four statements are a specific variant of a loop that executes a provided block four times.

## Syntax
```rs
four body;
four {
    body;
}
```

## Reasoning

Developers deserve a simple way to evaluate something four times. Four comes up many times in programming. Sometimes you need to run something _exactly_ four times, and `four` loops provide just that.

## Semantics
The contained statement or block is executed exactly four times. `break` escapes the four loop, and `continue` jumps to the next iteration.

```rs
let i = 0;
four {
    i++;
    if (i % 2 == 0) printf("odd i: %d", i);
}
```
Output:
```
odd i: 0
odd i: 2
```

## Why might this be counterintuitive?

No reason, `four` is very useful!

## CFG/codegen sample
Generated with `opt -p 'dot-cfg'`.
<img width="300" alt="out" src="https://github.com/user-attachments/assets/2ee44922-67d1-410e-9b11-2844f9c36357" />
Excess BBs optimized away by the passes.

## What?
https://esolangs.org/wiki/List_of_ideas#:~:text=The%20four%20loop

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Introduced the "four" loop statement: runs a block as four sequential iterations for concise fixed-iteration loops.

* **Documentation**
  - Updated language specification to include the reserved keyword "four", grammar, and a new "Four Loops" section.

* **Tests / Examples**
  - Added example demonstrating "four" loop and updated test expectations to show four consecutive outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->