### PR TITLE
chore: change all `#[allow]`s to `#[expect]`s

### DIFF
--- a/compiler/zrc/src/compile.rs
+++ b/compiler/zrc/src/compile.rs
@@ -29,7 +29,7 @@ use crate::OutputFormat;
 /// * `debug_mode` - The debug level for code generation.
 /// * `triple` - The target triple for code generation.
 /// * `cpu` - The target CPU for code generation.
-#[allow(
+#[expect(
     clippy::too_many_arguments,
     clippy::wildcard_enum_match_arm,
     clippy::result_large_err

--- a/compiler/zrc_codegen/src/expr.rs
+++ b/compiler/zrc_codegen/src/expr.rs
@@ -39,12 +39,7 @@ struct CgExprArgs<'ctx, 'input, 'a> {
 
 /// Generate LLVM IR for a [`TypedExpr`], returning a [`BasicBlockAnd`] with the
 /// resulting basic block and the computed value
-#[allow(
-    clippy::redundant_pub_crate,
-    clippy::too_many_lines,
-    clippy::match_same_arms,
-    clippy::too_many_arguments
-)]
+#[expect(clippy::redundant_pub_crate)]
 pub(crate) fn cg_expr<'ctx, 'input, 'a>(
     cg: BlockCtx<'ctx, 'input, 'a>,
     bb: BasicBlock<'ctx>,

--- a/compiler/zrc_codegen/src/expr/arithmetic.rs
+++ b/compiler/zrc_codegen/src/expr/arithmetic.rs
@@ -105,7 +105,7 @@ pub fn cg_arithmetic<'ctx, 'input>(
         // Most languages make incrementing a pointer increase the address by the size
         // of the pointee type, hence our use of `gep`.
         // REVIEW: Is this the approach we want to take?
-        #[allow(clippy::wildcard_enum_match_arm)]
+        #[expect(clippy::wildcard_enum_match_arm)]
         let reg = match op {
             // SAFETY: This can segfault if indices are used incorrectly
             // This is only used for pointer arithmetic, so the indices should be correct

--- a/compiler/zrc_codegen/src/expr/misc.rs
+++ b/compiler/zrc_codegen/src/expr/misc.rs
@@ -152,7 +152,7 @@ pub fn cg_struct_construction<'ctx, 'input>(
             let field_value = unpack!(bb = cg_expr(cg, bb, field_expr.clone()));
 
             // Get pointer to this field in the struct
-            #[allow(clippy::cast_possible_truncation, clippy::as_conversions)]
+            #[expect(clippy::cast_possible_truncation, clippy::as_conversions)]
             let field_ptr = cg
                 .builder
                 .build_struct_gep(struct_type, struct_ptr, idx as u32, "field_ptr")

--- a/compiler/zrc_codegen/src/expr/place.rs
+++ b/compiler/zrc_codegen/src/expr/place.rs
@@ -28,7 +28,6 @@ use crate::{
 };
 
 /// Resolve a place to its LLVM [`PointerValue`]
-#[allow(clippy::too_many_arguments, clippy::too_many_lines)]
 pub fn cg_place<'ctx>(
     cg: BlockCtx<'ctx, '_, '_>,
     mut bb: BasicBlock<'ctx>,
@@ -80,7 +79,7 @@ pub fn cg_place<'ctx>(
             bb.and(reg.as_basic_value_enum().into_pointer_value())
         }
 
-        #[allow(clippy::wildcard_enum_match_arm)]
+        #[expect(clippy::wildcard_enum_match_arm)]
         PlaceKind::Dot(x, prop) => match &x.inferred_type {
             Type::Struct(contents) => {
                 let x_ty = llvm_basic_type(&cg, &x.inferred_type).0;

--- a/compiler/zrc_codegen/src/program.rs
+++ b/compiler/zrc_codegen/src/program.rs
@@ -36,7 +36,7 @@ use crate::{
 /// # Panics
 ///
 /// Panics if the expression is not a valid constant expression.
-#[allow(clippy::too_many_lines, clippy::wildcard_enum_match_arm)]
+#[expect(clippy::wildcard_enum_match_arm)]
 fn eval_const_expr<'ctx>(
     unit: &CompilationUnitCtx<'ctx, '_>,
     expr: &zrc_typeck::tast::expr::TypedExpr,
@@ -98,7 +98,6 @@ fn eval_const_expr<'ctx>(
 /// Use [`cg_init_fn`] instead for definitions.
 /// We do not attach debugging info to extern functions, to follow with clang's
 /// (probably correct) behavior.
-#[allow(clippy::too_many_arguments)]
 pub fn cg_init_extern_fn<'ctx>(
     unit: &CompilationUnitCtx<'ctx, '_>,
     name: &str,
@@ -132,7 +131,6 @@ pub fn cg_init_extern_fn<'ctx>(
 
 /// Same as [`cg_init_extern_fn`] but properly initializes function
 /// *definitions* with their debugging information.
-#[allow(clippy::too_many_arguments)]
 pub fn cg_init_fn<'ctx>(
     unit: &CompilationUnitCtx<'ctx, '_>,
     name: &str,
@@ -197,7 +195,7 @@ fn optimize_module(module: &Module<'_>, tm: &TargetMachine, optimization_level: 
     // We must use FFI here because Inkwell does not expose the LLVM
     // optimization passes directly.
     unsafe {
-        #[allow(clippy::as_conversions)]
+        #[expect(clippy::as_conversions)]
         crate::zrc_codegen_optimize_module(
             module.as_mut_ptr(),
             tm.as_mut_ptr(),
@@ -213,7 +211,7 @@ fn optimize_module(module: &Module<'_>, tm: &TargetMachine, optimization_level: 
 /// Panics if code generation fails. This can be caused by an invalid TAST being
 /// passed, so make sure to type check it so invariants are upheld.
 #[must_use]
-#[allow(clippy::too_many_lines, clippy::too_many_arguments)]
+#[expect(clippy::too_many_lines, clippy::too_many_arguments)]
 fn cg_program_without_optimization<'ctx>(
     frontend_version_string: &str,
     cli_args: &str,
@@ -461,7 +459,7 @@ fn cg_program_without_optimization<'ctx>(
 /// Panics if code generation fails. This can be caused by an invalid TAST being
 /// passed, so make sure to type check it so invariants are upheld.
 #[must_use]
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 fn cg_program<'ctx>(
     frontend_version_string: &str,
     cli_args: &str,
@@ -496,7 +494,7 @@ fn cg_program<'ctx>(
 /// # Panics
 /// Panics on internal code generation failure.
 #[must_use]
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 pub fn cg_program_to_string(
     frontend_version_string: &str,
     parent_directory: &str,
@@ -548,7 +546,7 @@ pub fn cg_program_to_string(
 /// # Panics
 /// Panics on internal code generation failure.
 #[must_use]
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 // this function is currently only used in tests because the LLVM optimizer
 // doesn't handle well when multithreaded.
 #[cfg(test)]
@@ -603,7 +601,7 @@ pub fn cg_program_to_string_without_optimization(
 /// # Panics
 /// Panics on internal code generation failure.
 #[must_use]
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 pub fn cg_program_to_buffer(
     frontend_version_string: &str,
     parent_directory: &str,

--- a/compiler/zrc_codegen/src/stmt.rs
+++ b/compiler/zrc_codegen/src/stmt.rs
@@ -41,7 +41,7 @@ use crate::{
 /// instructions. It is passed to [`cg_block`] to allow it to properly handle
 /// break and continue.
 #[derive(PartialEq, Eq, Debug, Clone)]
-#[allow(clippy::redundant_pub_crate)]
+#[expect(clippy::redundant_pub_crate)]
 pub(crate) struct LoopBreakaway<'ctx> {
     /// Points to the exit basic block.
     on_break: BasicBlock<'ctx>,
@@ -54,10 +54,8 @@ pub(crate) struct LoopBreakaway<'ctx> {
 ///
 /// # Panics
 /// Panics if an internal code generation error is encountered.
-#[allow(
-    clippy::too_many_arguments,
+#[expect(
     clippy::too_many_lines,
-    clippy::needless_pass_by_value,
     clippy::redundant_pub_crate,
     clippy::ref_option
 )]

--- a/compiler/zrc_codegen/src/stmt/branch.rs
+++ b/compiler/zrc_codegen/src/stmt/branch.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 
 /// Code generates a switch statement
-#[allow(clippy::too_many_arguments, clippy::ref_option)]
+#[expect(clippy::too_many_arguments, clippy::ref_option)]
 pub fn cg_if_stmt<'ctx, 'input, 'a>(
     cg: FunctionCtx<'ctx, 'a>,
     bb: BasicBlock<'ctx>,

--- a/compiler/zrc_codegen/src/stmt/let_decl.rs
+++ b/compiler/zrc_codegen/src/stmt/let_decl.rs
@@ -22,7 +22,6 @@ use crate::{
 ///
 /// # Panics
 /// Panics if an internal code generation error is encountered.
-#[allow(clippy::too_many_arguments)]
 pub fn cg_let_declaration<'ctx, 'input, 'a>(
     cg: FunctionCtx<'ctx, 'a>,
     mut bb: BasicBlock<'ctx>,
@@ -54,7 +53,6 @@ pub fn cg_let_declaration<'ctx, 'input, 'a>(
             .get_first_basic_block()
             .expect("function should have at least one basic block");
 
-        #[allow(clippy::option_if_let_else)]
         match first_bb.get_first_instruction() {
             Some(first_instruction) => {
                 entry_block_builder.position_before(&first_instruction);

--- a/compiler/zrc_codegen/src/stmt/loops.rs
+++ b/compiler/zrc_codegen/src/stmt/loops.rs
@@ -17,7 +17,7 @@ use crate::{
 };
 
 /// Code generates a for statement
-#[allow(clippy::too_many_arguments, clippy::ref_option, clippy::box_collection)]
+#[expect(clippy::too_many_arguments, clippy::box_collection)]
 pub fn cg_for_stmt<'ctx, 'input, 'a>(
     cg: FunctionCtx<'ctx, 'a>,
     bb: BasicBlock<'ctx>,
@@ -119,7 +119,6 @@ pub fn cg_for_stmt<'ctx, 'input, 'a>(
 }
 
 /// Code generates a while statement
-#[allow(clippy::too_many_arguments, clippy::ref_option)]
 pub fn cg_while_stmt<'ctx, 'input, 'a>(
     cg: FunctionCtx<'ctx, 'a>,
     scope: &'a CgScope<'input, 'ctx>,
@@ -181,7 +180,6 @@ pub fn cg_while_stmt<'ctx, 'input, 'a>(
 }
 
 /// Code generates a do..while statement
-#[allow(clippy::too_many_arguments, clippy::ref_option)]
 pub fn cg_do_while_stmt<'ctx, 'input, 'a>(
     cg: FunctionCtx<'ctx, 'a>,
     scope: &'a CgScope<'input, 'ctx>,

--- a/compiler/zrc_codegen/src/stmt/switch.rs
+++ b/compiler/zrc_codegen/src/stmt/switch.rs
@@ -14,7 +14,7 @@ use crate::{
 };
 
 /// Code generates a switch statement
-#[allow(clippy::too_many_arguments, clippy::ref_option)]
+#[expect(clippy::too_many_arguments, clippy::ref_option)]
 pub fn cg_switch_stmt<'ctx, 'input, 'a>(
     cg: FunctionCtx<'ctx, 'a>,
     mut bb: BasicBlock<'ctx>,

--- a/compiler/zrc_codegen/src/ty.rs
+++ b/compiler/zrc_codegen/src/ty.rs
@@ -69,7 +69,6 @@ pub fn create_fn<'ctx: 'a, 'a>(
 ///
 /// # Panics
 /// Panics if `ty` is not an integer type
-#[allow(clippy::needless_pass_by_value)]
 pub fn llvm_int_type<'ctx: 'a, 'a>(
     ctx: &impl AsCompilationUnitCtx<'ctx, 'a>,
     ty: &Type,
@@ -105,7 +104,7 @@ pub fn llvm_int_type<'ctx: 'a, 'a>(
 ///
 /// # Panics
 /// Panics if `ty` is not a basic type
-#[allow(clippy::too_many_lines)]
+#[expect(clippy::too_many_lines)]
 pub fn llvm_basic_type<'ctx: 'a, 'a>(
     ctx: &impl AsCompilationUnitCtx<'ctx, 'a>,
     ty: &Type,

--- a/compiler/zrc_diagnostics/src/diagnostic_kind.rs
+++ b/compiler/zrc_diagnostics/src/diagnostic_kind.rs
@@ -11,7 +11,7 @@ use crate::{Diagnostic, Severity};
 /// raised during the compilation process.
 // These remain as Strings, not 'input str slices, to avoid circular dependencies (it's either use
 // String, or use Tok, because str would be to-string()d from some tokens)
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Error, Debug, PartialEq, Eq)]
 pub enum DiagnosticKind {
     // LEXER ERRORS

--- a/compiler/zrc_parser/src/ast/expr.rs
+++ b/compiler/zrc_parser/src/ast/expr.rs
@@ -244,7 +244,7 @@ pub enum ExprKind<'input> {
     SizeOfExpr(Box<Expr<'input>>),
 
     /// Struct construction: `new Type { field1: value1, field2: value2 }`
-    #[allow(clippy::type_complexity)]
+    #[expect(clippy::type_complexity)]
     StructConstruction(
         Type<'input>,
         Spanned<Vec<Spanned<(Spanned<&'input str>, Expr<'input>)>>>,
@@ -342,7 +342,7 @@ impl ExprKind<'_> {
 }
 
 impl std::fmt::Display for ExprKind<'_> {
-    #[allow(clippy::too_many_lines)]
+    #[expect(clippy::too_many_lines)]
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Comma(lhs, rhs) => {
@@ -504,9 +504,7 @@ impl std::fmt::Display for Expr<'_> {
 
 // AST builder. We are able to infer the spans of many based on the start of
 // their leftmost and the end of their rightmost operands.
-#[allow(missing_docs)]
-#[allow(clippy::missing_docs_in_private_items)]
-#[allow(clippy::should_implement_trait)]
+#[allow(missing_docs, clippy::missing_docs_in_private_items)]
 impl<'input> Expr<'input> {
     #[must_use]
     pub fn build_comma(lhs: Self, rhs: Self) -> Self {
@@ -845,7 +843,7 @@ impl<'input> Expr<'input> {
         ))
     }
     #[must_use]
-    #[allow(clippy::type_complexity)]
+    #[expect(clippy::type_complexity)]
     pub fn build_struct_construction(
         ty: Type<'input>,
         fields: Spanned<Vec<Spanned<(Spanned<&'input str>, Self)>>>,

--- a/compiler/zrc_parser/src/ast/ty.rs
+++ b/compiler/zrc_parser/src/ast/ty.rs
@@ -18,7 +18,7 @@ pub struct Type<'input>(pub Spanned<TypeKind<'input>>);
 
 /// The key-value pairs of a struct
 #[derive(PartialEq, Eq, Debug, Clone)]
-#[allow(clippy::type_complexity)]
+#[expect(clippy::type_complexity)]
 pub struct KeyTypeMapping<'input>(pub Spanned<Vec<Spanned<(Spanned<&'input str>, Type<'input>)>>>);
 impl Display for KeyTypeMapping<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -54,9 +54,7 @@ pub enum TypeKind<'input> {
 
 // AST builder. We are able to infer the spans of many based on the start of
 // their leftmost and the end of their rightmost operands.
-#[allow(missing_docs)]
-#[allow(clippy::missing_docs_in_private_items)]
-#[allow(clippy::should_implement_trait)]
+#[allow(missing_docs, clippy::missing_docs_in_private_items)]
 impl<'input> Type<'input> {
     #[must_use]
     pub fn build_ident(ident: Spanned<&'input str>) -> Self {

--- a/compiler/zrc_parser/src/parser.rs
+++ b/compiler/zrc_parser/src/parser.rs
@@ -107,7 +107,7 @@ fn zirco_lexer_span_to_lalrpop_span<'input>(
 /// # Errors
 /// This function returns [`Err`] with a [`Diagnostic`] if any error was
 /// encountered while parsing the input program.
-#[allow(clippy::result_large_err)]
+#[expect(clippy::result_large_err)]
 pub fn parse_program<'input>(
     input: &'input str,
     file_name: &'static str,
@@ -138,7 +138,7 @@ pub fn parse_program<'input>(
 /// # Errors
 /// This function returns [`Err`] with a [`Diagnostic`] if any error was
 /// encountered while parsing the input statement list.
-#[allow(clippy::result_large_err)]
+#[expect(clippy::result_large_err)]
 pub fn parse_stmt_list<'input>(
     input: &'input str,
     file_name: &'static str,
@@ -171,7 +171,7 @@ pub fn parse_stmt_list<'input>(
 /// # Errors
 /// This function returns [`Err`] with a [`Diagnostic`] if any error was
 /// encountered while parsing the input expression.
-#[allow(clippy::result_large_err)]
+#[expect(clippy::result_large_err)]
 pub fn parse_type<'input>(
     input: &'input str,
     file_name: &'static str,
@@ -201,7 +201,7 @@ pub fn parse_type<'input>(
 /// # Errors
 /// This function returns [`Err`] with a [`Diagnostic`] if any error was
 /// encountered while parsing the input expression.
-#[allow(clippy::result_large_err)]
+#[expect(clippy::result_large_err)]
 pub fn parse_expr<'input>(
     input: &'input str,
     file_name: &'static str,
@@ -222,7 +222,7 @@ pub fn parse_expr<'input>(
 /// # Errors
 /// This function returns [`Err`] with a diagnostic if any error was
 /// encountered while parsing the chunk.
-#[allow(clippy::result_large_err)]
+#[expect(clippy::result_large_err)]
 pub fn parse_source_chunk(
     chunk: &zrc_preprocessor::SourceChunk,
 ) -> Result<Vec<Spanned<Declaration<'_>>>, Diagnostic> {

--- a/compiler/zrc_preprocessor/src/lib.rs
+++ b/compiler/zrc_preprocessor/src/lib.rs
@@ -133,7 +133,7 @@ fn find_include_file(ctx: &PreprocessorCtx, include_file: &str) -> Option<PathBu
 /// - An included file cannot be found
 /// - An included file cannot be read
 /// - A preprocessing directive is malformed
-#[allow(clippy::result_large_err)]
+#[expect(clippy::result_large_err)]
 pub fn preprocess(
     base_path: &Path,
     search_paths: Vec<&'static Path>,
@@ -146,7 +146,7 @@ pub fn preprocess(
 }
 
 /// Internal recursive preprocessing function
-#[allow(clippy::too_many_lines, clippy::result_large_err)]
+#[expect(clippy::too_many_lines, clippy::result_large_err)]
 fn preprocess_internal(
     base_path: &Path,
     file_name: &str,

--- a/compiler/zrc_typeck/src/tast/expr.rs
+++ b/compiler/zrc_typeck/src/tast/expr.rs
@@ -24,7 +24,7 @@ pub struct Place<'input> {
 /// Places may be:
 /// - A variable or an property access of a place
 /// - A dereference or index into any expression yielding a pointer
-#[allow(variant_size_differences)]
+#[expect(variant_size_differences)]
 #[derive(PartialEq, Debug, Clone)]
 pub enum PlaceKind<'input> {
     /// `*x`
@@ -263,7 +263,7 @@ impl Display for TypedExpr<'_> {
 }
 
 impl Display for TypedExprKind<'_> {
-    #[allow(clippy::too_many_lines)]
+    #[expect(clippy::too_many_lines)]
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Comma(lhs, rhs) => {

--- a/compiler/zrc_typeck/src/tast/stmt.rs
+++ b/compiler/zrc_typeck/src/tast/stmt.rs
@@ -80,7 +80,6 @@ pub enum TypedStmtKind<'input> {
 }
 
 /// A struct or function declaration at the top level of a file
-#[allow(variant_size_differences)]
 #[derive(Debug, Clone, PartialEq)]
 pub enum TypedDeclaration<'input> {
     /// A declaration of a function
@@ -187,7 +186,7 @@ impl Display for TypedStmt<'_> {
 }
 
 impl Display for TypedStmtKind<'_> {
-    #[allow(clippy::too_many_lines)]
+    #[expect(clippy::too_many_lines)]
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::IfStmt(cond, if_true, None) => {

--- a/compiler/zrc_typeck/src/tast/ty.rs
+++ b/compiler/zrc_typeck/src/tast/ty.rs
@@ -148,7 +148,7 @@ impl<'input> Type<'input> {
 
     /// Try to get the value we point at, or None if not a pointer.
     #[must_use]
-    #[allow(clippy::wildcard_enum_match_arm)]
+    #[expect(clippy::wildcard_enum_match_arm)]
     pub fn into_pointee(self) -> Option<Self> {
         match self {
             Type::Ptr(x) => Some(*x),
@@ -158,7 +158,7 @@ impl<'input> Type<'input> {
 
     /// Try to access the struct's [`IndexMap`] if we are a struct
     #[must_use]
-    #[allow(clippy::wildcard_enum_match_arm)]
+    #[expect(clippy::wildcard_enum_match_arm)]
     pub fn into_struct_contents(self) -> Option<IndexMap<&'input str, Self>> {
         match self {
             Type::Struct(x) => Some(x),
@@ -168,7 +168,7 @@ impl<'input> Type<'input> {
 
     /// Try to access the union's [`IndexMap`] if we are a union
     #[must_use]
-    #[allow(clippy::wildcard_enum_match_arm)]
+    #[expect(clippy::wildcard_enum_match_arm)]
     pub fn into_union_contents(self) -> Option<IndexMap<&'input str, Self>> {
         match self {
             Type::Union(x) => Some(x),

--- a/compiler/zrc_typeck/src/typeck/block.rs
+++ b/compiler/zrc_typeck/src/typeck/block.rs
@@ -55,7 +55,7 @@ use crate::tast::{
 /// Panics in some internal state failures.
 // TODO: Maybe the TAST should attach the BlockReturnActuality in each BlockStmt itself and preserve
 // it on sub-blocks in the TAST (this may be helpful in control flow analysis)
-#[allow(clippy::too_many_lines)]
+#[expect(clippy::too_many_lines)]
 pub fn type_block<'input, 'gs>(
     parent_scope: &Scope<'input, 'gs>,
     input_block: Spanned<Vec<Stmt<'input>>>,

--- a/compiler/zrc_typeck/src/typeck/block/block_utils.rs
+++ b/compiler/zrc_typeck/src/typeck/block/block_utils.rs
@@ -10,7 +10,7 @@ use zrc_utils::span::{Spannable, Spanned};
 pub fn coerce_stmt_into_block(stmt: Stmt<'_>) -> Spanned<Vec<Stmt<'_>>> {
     let span = stmt.0.span();
 
-    #[allow(clippy::wildcard_enum_match_arm)]
+    #[expect(clippy::wildcard_enum_match_arm)]
     stmt.0.map(|value| match value {
         StmtKind::BlockStmt(stmts) => stmts,
         stmt_kind => vec![Stmt(stmt_kind.in_span(span))],

--- a/compiler/zrc_typeck/src/typeck/block/branch.rs
+++ b/compiler/zrc_typeck/src/typeck/block/branch.rs
@@ -16,7 +16,7 @@ use crate::tast::{
 };
 
 /// Type check an if statement.
-#[allow(clippy::needless_pass_by_value)]
+#[expect(clippy::needless_pass_by_value)]
 pub fn type_if<'input>(
     scope: &Scope<'input, '_>,
     cond: Expr<'input>,

--- a/compiler/zrc_typeck/src/typeck/block/cfa.rs
+++ b/compiler/zrc_typeck/src/typeck/block/cfa.rs
@@ -73,7 +73,6 @@ impl BlockReturnActuality {
     /// Sometimes + Always => Sometimes
     /// Always + Always => Always
     #[must_use]
-    #[allow(clippy::min_ident_chars)]
     pub const fn join(a: Self, b: Self) -> Self {
         match (a, b) {
             (Self::NeverReturns, Self::NeverReturns) => Self::NeverReturns,

--- a/compiler/zrc_typeck/src/typeck/block/switch_match.rs
+++ b/compiler/zrc_typeck/src/typeck/block/switch_match.rs
@@ -20,7 +20,7 @@ use crate::tast::{
 };
 
 /// Type check a switch case statement.
-#[allow(clippy::ptr_arg)]
+#[expect(clippy::ptr_arg)]
 pub fn type_switch_case<'input>(
     scope: &Scope<'input, '_>,
     scrutinee: Expr<'input>,
@@ -122,7 +122,7 @@ pub fn type_switch_case<'input>(
 }
 
 /// Desugar and type check a match statement.
-#[allow(clippy::too_many_lines, clippy::needless_pass_by_value)]
+#[expect(clippy::too_many_lines, clippy::needless_pass_by_value)]
 pub fn type_match<'input>(
     scope: &Scope<'input, '_>,
     scrutinee: Expr<'input>,
@@ -207,7 +207,7 @@ pub fn type_match<'input>(
 
     // Ensure each enum variant is covered by exactly one case
     // We do this by sorting both lists and comparing them
-    #[allow(clippy::useless_asref)]
+    #[expect(clippy::useless_asref)]
     let mut sorted_enum_variants: Vec<(&str, &TastType<'_>)> = enum_as_union_def
         .iter()
         .map(|(name, ty)| (name.as_ref(), ty))

--- a/compiler/zrc_typeck/src/typeck/declaration.rs
+++ b/compiler/zrc_typeck/src/typeck/declaration.rs
@@ -34,7 +34,6 @@ pub const fn is_constant_expr(expr: &TypedExpr) -> bool {
 ///
 /// # Errors
 /// Errors if a type checker error is encountered.
-#[allow(clippy::too_many_lines, clippy::missing_panics_doc)]
 pub fn process_declaration<'input>(
     global_scope: &mut GlobalScope<'input>,
     declaration: AstDeclaration<'input>,

--- a/compiler/zrc_typeck/src/typeck/declaration/func.rs
+++ b/compiler/zrc_typeck/src/typeck/declaration/func.rs
@@ -24,7 +24,7 @@ use crate::tast::{
 ///
 /// # Errors
 /// Errors if a type checker error is encountered.
-#[allow(clippy::too_many_lines, clippy::needless_pass_by_value)]
+#[expect(clippy::too_many_lines, clippy::needless_pass_by_value)]
 pub fn process_function_declaration<'input>(
     global_scope: &mut GlobalScope<'input>,
     name: Spanned<&'input str>,

--- a/compiler/zrc_typeck/src/typeck/expr.rs
+++ b/compiler/zrc_typeck/src/typeck/expr.rs
@@ -23,7 +23,6 @@ use crate::tast::expr::TypedExpr;
 ///
 /// # Errors
 /// Errors if a type checker error is encountered.
-#[allow(clippy::missing_panics_doc)]
 pub fn type_expr<'input>(
     scope: &Scope<'input, '_>,
     expr: Expr<'input>,
@@ -102,7 +101,7 @@ mod tests {
     };
 
     #[test]
-    #[allow(clippy::too_many_lines)]
+    #[expect(clippy::too_many_lines)]
     fn various_expressions_infer_correctly() {
         let scope = GlobalScope {
             global_values: ValueCtx::from_mappings(HashMap::from([

--- a/compiler/zrc_typeck/src/typeck/expr/call.rs
+++ b/compiler/zrc_typeck/src/typeck/expr/call.rs
@@ -16,7 +16,7 @@ use crate::tast::{
 };
 
 /// Typeck a call expr
-#[allow(clippy::needless_pass_by_value, clippy::too_many_lines)]
+#[expect(clippy::needless_pass_by_value, clippy::too_many_lines)]
 pub fn type_expr_call<'input>(
     scope: &Scope<'input, '_>,
     expr_span: Span,
@@ -31,7 +31,7 @@ pub fn type_expr_call<'input>(
         .map(|x| type_expr(scope, x.clone()))
         .collect::<Result<Vec<TypedExpr>, Diagnostic>>()?;
 
-    #[allow(clippy::wildcard_enum_match_arm)]
+    #[expect(clippy::wildcard_enum_match_arm)]
     match ft.inferred_type.clone() {
         TastType::Fn(Fn {
             arguments: ArgumentDeclarationList::NonVariadic(arg_types),

--- a/compiler/zrc_typeck/src/typeck/expr/helpers.rs
+++ b/compiler/zrc_typeck/src/typeck/expr/helpers.rs
@@ -43,7 +43,7 @@ pub fn expr_to_place(span: Span, expr: TypedExpr) -> Result<Place, Diagnostic> {
     let kind_span = expr.kind.span();
     let stringified = expr.inferred_type.to_string();
 
-    #[allow(clippy::wildcard_enum_match_arm)]
+    #[expect(clippy::wildcard_enum_match_arm)]
     Ok(match expr.kind.into_value() {
         TypedExprKind::UnaryDereference(x) => Place {
             inferred_type: expr.inferred_type,

--- a/compiler/zrc_typeck/src/typeck/expr/literals.rs
+++ b/compiler/zrc_typeck/src/typeck/expr/literals.rs
@@ -44,7 +44,7 @@ pub fn type_expr_number_literal<'input>(
         .expect("Number literal should have been valid");
 
     // Check bounds based on type
-    #[allow(clippy::wildcard_enum_match_arm)]
+    #[expect(clippy::wildcard_enum_match_arm)]
     let bounds = match ty_resolved {
         TastType::I8 => Some((i8::MIN.into(), i8::MAX.into())),
         TastType::U8 => Some((u8::MIN.into(), u8::MAX.into())),
@@ -62,8 +62,8 @@ pub fn type_expr_number_literal<'input>(
     if let Some((min, max)) = bounds {
         // Check if the value fits in the range
         // We need to handle unsigned values that might be larger than i128::MAX
-        #[allow(clippy::cast_possible_wrap)]
-        #[allow(clippy::as_conversions)]
+        #[expect(clippy::cast_possible_wrap)]
+        #[expect(clippy::as_conversions)]
         let value_in_range = u128::try_from(i128::MAX).ok().is_some_and(|max_as_u128| {
             if parsed_value <= max_as_u128 {
                 let value_as_signed = parsed_value as i128;

--- a/compiler/zrc_typeck/src/typeck/expr/misc.rs
+++ b/compiler/zrc_typeck/src/typeck/expr/misc.rs
@@ -197,7 +197,7 @@ pub fn type_expr_size_of_expr<'input>(
 }
 
 /// Typeck a struct construction expr
-#[allow(clippy::type_complexity)]
+#[expect(clippy::type_complexity)]
 pub fn type_expr_struct_construction<'input>(
     scope: &Scope<'input, '_>,
     expr_span: Span,

--- a/compiler/zrc_typeck/src/typeck/scope.rs
+++ b/compiler/zrc_typeck/src/typeck/scope.rs
@@ -113,7 +113,6 @@ impl<'input> ValueCtx<'input> {
     /// Create a new empty [`ValueScope`].
     // Does not impl [Default] because a default would be misleading: the "empty" scope is more
     // accurate.
-    #[allow(clippy::new_without_default)]
     #[must_use]
     pub fn new() -> Self {
         Self {

--- a/compiler/zrc_typeck/src/typeck/ty.rs
+++ b/compiler/zrc_typeck/src/typeck/ty.rs
@@ -130,7 +130,7 @@ fn resolve_type_with_opaque<'input>(
 ///
 /// # Errors
 /// Returns an error if an opaque type is found not behind a pointer.
-#[allow(clippy::wildcard_enum_match_arm)]
+#[expect(clippy::wildcard_enum_match_arm)]
 fn check_opaque_behind_pointer<'input>(
     ty: &TastType<'input>,
     opaque_name: &'input str,
@@ -175,7 +175,7 @@ pub fn resolve_type_with_self_reference<'input>(
 /// Replace all opaque type references with the concrete type.
 /// For self-referential types behind pointers, replaces with an empty struct
 /// as a placeholder since pointers don't need to know the full pointee type.
-#[allow(clippy::wildcard_enum_match_arm)]
+#[expect(clippy::wildcard_enum_match_arm)]
 fn replace_opaque_with_concrete<'input>(
     ty: TastType<'input>,
     opaque_name: &'input str,
@@ -220,7 +220,6 @@ fn replace_opaque_with_concrete<'input>(
 ///
 /// # Errors
 /// Errors if a key is not unique or is unresolvable.
-#[allow(clippy::type_complexity)]
 pub(super) fn resolve_key_type_mapping<'input>(
     type_scope: &TypeCtx<'input>,
     members: KeyTypeMapping<'input>,
@@ -247,7 +246,6 @@ pub(super) fn resolve_key_type_mapping<'input>(
 /// # Errors
 /// Errors if a key is not unique, is unresolvable, or contains a
 /// self-referential type not behind a pointer.
-#[allow(clippy::type_complexity)]
 fn resolve_key_type_mapping_with_opaque<'input>(
     type_scope: &TypeCtx<'input>,
     members: KeyTypeMapping<'input>,

--- a/compiler/zrc_utils/src/span.rs
+++ b/compiler/zrc_utils/src/span.rs
@@ -146,7 +146,6 @@ impl<T> Spanned<T> {
     ///
     /// This differs from [`Spanned::value`] because it consumes the
     /// [`Spanned<T>`] instance and drops the [`Span`].
-    #[allow(clippy::missing_const_for_fn)]
     #[inline]
     pub fn into_value(self) -> T {
         self.1
@@ -193,7 +192,7 @@ impl<T, E> Spanned<Result<T, E>> {
     /// Converts a [`Spanned<Result<T, E>>`] to a [`Result<Spanned<T>,
     /// Spanned<E>>`]. Note: This is not reversible. See the note on
     /// [`Spanned<Option<T>>::transpose`].
-    #[allow(clippy::missing_errors_doc)] // just propagates input error
+    #[expect(clippy::missing_errors_doc)] // just propagates input error
     pub fn transpose(self) -> Result<Spanned<T>, Spanned<E>> {
         let span = self.span();
         self.into_value()
@@ -283,7 +282,7 @@ mod tests {
         }
 
         #[test]
-        #[allow(clippy::let_underscore_must_use)]
+        #[expect(clippy::let_underscore_must_use)]
         #[should_panic(expected = "span must have positive length")]
         fn span_from_invalid_positions_panics() {
             let _ = Span::from_positions_and_file(5, 0, "<test>");


### PR DESCRIPTION
Clippy has this `#[expect]` thing I never realized existed, so changing
all (*most*) of these helps us remove unnecessary lint allows and keep
the codebase cleaner.

(*most*: `#[allow(missing_docs)]` is still reasonable)
