### PR TITLE
Add short flag option for version command

### DIFF
--- a/tools/zircop/src/cli.rs
+++ b/tools/zircop/src/cli.rs
@@ -9,7 +9,7 @@ use clap::Parser;
 
 /// The official Zirco linter
 #[derive(Parser)]
-#[command(version)]
+#[command(version, short_flag = 'v')]
 pub struct Cli {
     /// The path of the file to lint
     pub path: Option<PathBuf>,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the `-v` short flag to display version information in the CLI tool, providing a quicker alternative to the full version command.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->