### PR TITLE
test: add unit tests for Zircop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1703,6 +1703,7 @@ dependencies = [
  "anyhow",
  "clap",
  "derive_more",
+ "indoc",
  "thiserror",
  "zrc_diagnostics",
  "zrc_parser",

--- a/tools/zircop/Cargo.toml
+++ b/tools/zircop/Cargo.toml
@@ -15,3 +15,6 @@ thiserror = "2.0.17"
 derive_more = { version = "2.0.1", features = ["display"] }
 clap = { version = "4.5.52", features = ["derive"] }
 anyhow = "1.0.100"
+
+[dev-dependencies]
+indoc = "2.0.7"

--- a/tools/zircop/src/lib.rs
+++ b/tools/zircop/src/lib.rs
@@ -57,4 +57,6 @@ pub mod lint;
 pub mod lints;
 pub mod pass;
 pub mod runner;
+#[cfg(test)]
+pub mod test_utils;
 pub mod visit;

--- a/tools/zircop/src/lints/empty_struct_used.rs
+++ b/tools/zircop/src/lints/empty_struct_used.rs
@@ -58,3 +58,24 @@ impl<'input> SyntacticVisit<'input> for Visit {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use indoc::indoc;
+    use zrc_utils::spanned_test;
+
+    use super::*;
+    use crate::zircop_lint_test;
+
+    zircop_lint_test! {
+        name: empty_struct_declaration,
+        source: indoc!{"
+            struct EmptyStruct {}
+        "},
+        diagnostics: vec![
+            LintDiagnostic::new(
+                spanned_test!(0, LintDiagnosticKind::EmptyStructUsed, 21)
+            ),
+        ]
+    }
+}

--- a/tools/zircop/src/lints/underscore_variable_used.rs
+++ b/tools/zircop/src/lints/underscore_variable_used.rs
@@ -85,3 +85,31 @@ impl<'input, 'gs> SemanticVisit<'input, 'gs> for Visit<'input> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use indoc::indoc;
+    use zrc_utils::spanned_test;
+
+    use super::*;
+    use crate::zircop_lint_test;
+
+    zircop_lint_test! {
+        name: underscore_variable_used_lints_properly,
+        source: indoc!{"
+            fn f() -> i32 {
+                let _used = 10;
+                return _used;
+            }
+        "},
+        diagnostics: vec![
+            LintDiagnostic::new(
+                spanned_test!(
+                    24,
+                    LintDiagnosticKind::UnderscoreVariableUsed("_used".to_string()),
+                    34
+                )
+            ),
+        ]
+    }
+}

--- a/tools/zircop/src/lints/unused_variables.rs
+++ b/tools/zircop/src/lints/unused_variables.rs
@@ -82,3 +82,32 @@ impl<'input, 'gs> SemanticVisit<'input, 'gs> for Visit<'input> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use indoc::indoc;
+    use zrc_utils::spanned_test;
+
+    use super::*;
+    use crate::zircop_lint_test;
+
+    zircop_lint_test! {
+        name: unused_variables_lints_properly,
+        source: indoc!{"
+            fn f() -> i32 {
+                let unused = 10;
+                let _with_underscore = 7;
+                return 0;
+            }
+        "},
+        diagnostics: vec![
+            LintDiagnostic::new(
+                spanned_test!(
+                    24,
+                    LintDiagnosticKind::UnusedVariable("unused".to_string()),
+                    35
+                )
+            ),
+        ]
+    }
+}

--- a/tools/zircop/src/test_utils.rs
+++ b/tools/zircop/src/test_utils.rs
@@ -1,0 +1,38 @@
+//! Extra utilities to aid in testing Zircop
+//!
+//! Only available on crate feature `test`.
+//!
+//! # Common patterns in tests
+//! The tests for Zircop often involve executing the Zircop runner on a small
+//! sample program and checking if a particular diagnostic is produced or not.
+
+/// Creates a Zircop test that runs the given source code and checks diagnostics
+/// against a list
+#[macro_export]
+macro_rules! zircop_lint_test {
+    (
+        name: $name:ident,
+        source: $source:expr,
+        diagnostics: $diagnostics:expr
+    ) => {
+        #[test]
+        fn $name() {
+            let include_paths = vec![];
+            let parent_directory = std::path::Path::new("");
+            let file_name = "<test>";
+
+            let lint_result = $crate::runner::run_with_default_passes(
+                include_paths,
+                parent_directory,
+                file_name,
+                $source,
+            )
+            .expect("Compilation should succeed");
+
+            assert_eq!(
+                lint_result, $diagnostics,
+                "Diagnostics did not match expected"
+            );
+        }
+    };
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added unit test coverage for the `empty_struct_used` lint to verify struct usage detection
  * Added unit test coverage for the `underscore_variable_used` lint to verify underscore-prefixed variable handling
  * Added unit test coverage for the `unused_variables` lint to verify unused variable detection and underscore-prefixed binding exclusion
  * Introduced test utilities macro to simplify lint test development

* **Chores**
  * Added development dependency to support test infrastructure

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->