### PR TITLE
try to fix debuginfo

### DIFF
--- a/compiler/zrc_codegen/src/ctx.rs
+++ b/compiler/zrc_codegen/src/ctx.rs
@@ -49,13 +49,13 @@ pub trait AsCompilationUnitCtx<'ctx: 'a, 'a> {
     /// The LLVM builder for debug info
     ///
     /// This is useful for creating debug info metadata.
-    fn dbg_builder(&self) -> &'a DebugInfoBuilder<'ctx> {
+    fn dbg_builder(&self) -> Option<&'a DebugInfoBuilder<'ctx>> {
         self.as_unit_ctx().dbg_builder
     }
     /// The LLVM compile unit for debug info
     ///
     /// This is useful for creating debug info metadata.
-    fn compilation_unit(&self) -> &'a DICompileUnit<'ctx> {
+    fn compilation_unit(&self) -> Option<&'a DICompileUnit<'ctx>> {
         self.as_unit_ctx().compilation_unit
     }
     /// The LLVM module we are building in
@@ -84,9 +84,9 @@ pub struct CompilationUnitCtx<'ctx, 'a> {
     /// The lookup for lines in the source file
     pub line_lookup: &'a LineLookup,
     /// The LLVM builder for debug info
-    pub dbg_builder: &'a DebugInfoBuilder<'ctx>,
+    pub dbg_builder: Option<&'a DebugInfoBuilder<'ctx>>,
     /// The LLVM compile unit for debug info
-    pub compilation_unit: &'a DICompileUnit<'ctx>,
+    pub compilation_unit: Option<&'a DICompileUnit<'ctx>>,
     /// The LLVM module we are building in
     pub module: &'a Module<'ctx>,
 }
@@ -115,9 +115,9 @@ pub struct FunctionCtx<'ctx, 'a> {
     /// The lookup for lines in the source file
     pub line_lookup: &'a LineLookup,
     /// The LLVM builder for debug info
-    pub dbg_builder: &'a DebugInfoBuilder<'ctx>,
+    pub dbg_builder: Option<&'a DebugInfoBuilder<'ctx>>,
     /// The LLVM compile unit for debug info
-    pub compilation_unit: &'a DICompileUnit<'ctx>,
+    pub compilation_unit: Option<&'a DICompileUnit<'ctx>>,
     /// The LLVM module we are building in
     pub module: &'a Module<'ctx>,
 
@@ -177,9 +177,9 @@ pub struct BlockCtx<'ctx, 'input, 'a> {
     /// The lookup for lines in the source file
     pub line_lookup: &'a LineLookup,
     /// The LLVM builder for debug info
-    pub dbg_builder: &'a DebugInfoBuilder<'ctx>,
+    pub dbg_builder: Option<&'a DebugInfoBuilder<'ctx>>,
     /// The LLVM compile unit for debug info
-    pub compilation_unit: &'a DICompileUnit<'ctx>,
+    pub compilation_unit: Option<&'a DICompileUnit<'ctx>>,
     /// The LLVM module we are building in
     pub module: &'a Module<'ctx>,
 
@@ -190,7 +190,7 @@ pub struct BlockCtx<'ctx, 'input, 'a> {
     /// The code generation type/value scope this block lives in
     pub scope: &'a CgScope<'input, 'ctx>,
     /// The LLVM [`DILexicalBlock`] we're currently in
-    pub dbg_scope: DILexicalBlock<'ctx>,
+    pub dbg_scope: Option<DILexicalBlock<'ctx>>,
 }
 impl<'ctx, 'a> AsCompilationUnitCtx<'ctx, 'a> for BlockCtx<'ctx, '_, 'a> {
     fn as_unit_ctx(&self) -> CompilationUnitCtx<'ctx, 'a> {
@@ -211,7 +211,7 @@ impl<'ctx, 'input, 'a> BlockCtx<'ctx, 'input, 'a> {
     pub const fn new(
         function_ctx: FunctionCtx<'ctx, 'a>,
         scope: &'a CgScope<'input, 'ctx>,
-        dbg_scope: DILexicalBlock<'ctx>,
+        dbg_scope: Option<DILexicalBlock<'ctx>>,
     ) -> Self {
         Self {
             ctx: function_ctx.ctx,

--- a/compiler/zrc_codegen/src/expr.rs
+++ b/compiler/zrc_codegen/src/expr.rs
@@ -47,14 +47,17 @@ pub(crate) fn cg_expr<'ctx, 'input, 'a>(
 ) -> BasicBlockAnd<'ctx, BasicValueEnum<'ctx>> {
     let expr_span = expr.kind.span();
     let line_and_col = cg.line_lookup.lookup_from_index(expr_span.start());
-    let debug_location = cg.dbg_builder.create_debug_location(
-        cg.ctx,
-        line_and_col.line,
-        line_and_col.col,
-        cg.dbg_scope.as_debug_info_scope(),
-        None,
-    );
-    cg.builder.set_current_debug_location(debug_location);
+    let _debug_location = cg.dbg_builder.as_ref().map(|dbg_builder| {
+        let dl = dbg_builder.create_debug_location(
+            cg.ctx,
+            line_and_col.line,
+            line_and_col.col,
+            cg.dbg_scope.expect("we have DI").as_debug_info_scope(),
+            None,
+        );
+        cg.builder.set_current_debug_location(dl);
+        dl
+    });
 
     let ce = CgExprArgs::<'ctx, 'input, 'a> {
         cg,

--- a/compiler/zrc_codegen/src/expr/place.rs
+++ b/compiler/zrc_codegen/src/expr/place.rs
@@ -35,14 +35,17 @@ pub fn cg_place<'ctx>(
 ) -> BasicBlockAnd<'ctx, PointerValue<'ctx>> {
     let place_span = place.kind.span();
     let line_and_col = cg.line_lookup.lookup_from_index(place_span.start());
-    let debug_location = cg.dbg_builder.create_debug_location(
-        cg.ctx,
-        line_and_col.line,
-        line_and_col.col,
-        cg.dbg_scope.as_debug_info_scope(),
-        None,
-    );
-    cg.builder.set_current_debug_location(debug_location);
+    let _debug_location = cg.dbg_builder.as_ref().map(|dbg_builder| {
+        let dl = dbg_builder.create_debug_location(
+            cg.ctx,
+            line_and_col.line,
+            line_and_col.col,
+            cg.dbg_scope.expect("we have DI").as_debug_info_scope(),
+            None,
+        );
+        cg.builder.set_current_debug_location(dl);
+        dl
+    });
 
     match place.kind.into_value() {
         PlaceKind::Variable(x) => {

--- a/compiler/zrc_codegen/src/program.rs
+++ b/compiler/zrc_codegen/src/program.rs
@@ -250,11 +250,14 @@ fn cg_program_without_optimization<'ctx>(
     let module = ctx.create_module(file_name);
 
     let debug_metadata_version = ctx.i32_type().const_int(3, false);
-    module.add_basic_value_flag(
-        "Debug Info Version",
-        FlagBehavior::Warning,
-        debug_metadata_version,
-    );
+
+    if debug_level != DWARFEmissionKind::None {
+        module.add_basic_value_flag(
+            "Debug Info Version",
+            FlagBehavior::Warning,
+            debug_metadata_version,
+        );
+    }
 
     let (dbg_builder, compilation_unit) = match debug_level {
         DWARFEmissionKind::Full => {

--- a/compiler/zrc_codegen/src/program.rs
+++ b/compiler/zrc_codegen/src/program.rs
@@ -283,7 +283,27 @@ fn cg_program_without_optimization<'ctx>(
             );
             (Some(dbg), Some(cu))
         }
-        DWARFEmissionKind::LineTablesOnly | DWARFEmissionKind::None => (None, None),
+        DWARFEmissionKind::LineTablesOnly => {
+            let (dbg, cu) = module.create_debug_info_builder(
+                true,
+                DWARFSourceLanguage::C,
+                file_name,
+                parent_directory,
+                frontend_version_string,
+                false,
+                cli_args,
+                0,
+                "",
+                DWARFEmissionKind::LineTablesOnly,
+                0,
+                false,
+                false,
+                "",
+                "",
+            );
+            (Some(dbg), Some(cu))
+        }
+        DWARFEmissionKind::None => (None, None),
     };
 
     let unit = CompilationUnitCtx {

--- a/compiler/zrc_codegen/src/stmt/loops.rs
+++ b/compiler/zrc_codegen/src/stmt/loops.rs
@@ -22,7 +22,7 @@ pub fn cg_for_stmt<'ctx, 'input, 'a>(
     cg: FunctionCtx<'ctx, 'a>,
     bb: BasicBlock<'ctx>,
     scope: &'a CgScope<'input, 'ctx>,
-    lexical_block: DILexicalBlock<'ctx>,
+    lexical_block: Option<DILexicalBlock<'ctx>>,
     init: Option<Box<Vec<Spanned<LetDeclaration<'input>>>>>,
     cond: Option<TypedExpr<'input>>,
     post: Option<TypedExpr<'input>>,
@@ -124,7 +124,7 @@ pub fn cg_four_stmt<'ctx, 'input, 'gs, 'a>(
     cg: FunctionCtx<'ctx, 'a>,
     bb: BasicBlock<'ctx>,
     scope: &'a CgScope<'input, 'ctx>,
-    lexical_block: DILexicalBlock<'ctx>,
+    lexical_block: Option<DILexicalBlock<'ctx>>,
     body: Spanned<BlockMetadata<'input, 'gs>>,
 ) -> BasicBlock<'ctx> {
     let mut current_bb = bb;
@@ -186,7 +186,7 @@ pub fn cg_four_stmt<'ctx, 'input, 'gs, 'a>(
 pub fn cg_while_stmt<'ctx, 'input, 'a>(
     cg: FunctionCtx<'ctx, 'a>,
     scope: &'a CgScope<'input, 'ctx>,
-    lexical_block: DILexicalBlock<'ctx>,
+    lexical_block: Option<DILexicalBlock<'ctx>>,
     cond: TypedExpr<'input>,
     body: Spanned<BlockMetadata<'input, '_>>,
 ) -> BasicBlock<'ctx> {
@@ -247,7 +247,7 @@ pub fn cg_while_stmt<'ctx, 'input, 'a>(
 pub fn cg_do_while_stmt<'ctx, 'input, 'a>(
     cg: FunctionCtx<'ctx, 'a>,
     scope: &'a CgScope<'input, 'ctx>,
-    lexical_block: DILexicalBlock<'ctx>,
+    lexical_block: Option<DILexicalBlock<'ctx>>,
     body: Spanned<BlockMetadata<'input, '_>>,
     cond: TypedExpr<'input>,
 ) -> BasicBlock<'ctx> {

--- a/compiler/zrc_codegen/src/stmt/switch.rs
+++ b/compiler/zrc_codegen/src/stmt/switch.rs
@@ -19,7 +19,7 @@ pub fn cg_switch_stmt<'ctx, 'input, 'gs, 'a>(
     cg: FunctionCtx<'ctx, 'a>,
     mut bb: BasicBlock<'ctx>,
     scope: &'a CgScope<'input, 'ctx>,
-    lexical_block: DILexicalBlock<'ctx>,
+    lexical_block: Option<DILexicalBlock<'ctx>>,
     breakaway: &Option<LoopBreakaway<'ctx>>,
     stmt_span: Span,
     scrutinee: TypedExpr<'input>,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Code generation now treats debug information as optional, allowing builds without debug symbols and avoiding unnecessary debug-data operations when debug level is disabled.
  * Public APIs updated to accept and return optional debug metadata so compilation gracefully handles absence of debug info.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->