### PR TITLE
refactor: replace ValueEntry::used with referenced_spans

### DIFF
--- a/compiler/zrc_typeck/src/typeck/expr/literals.rs
+++ b/compiler/zrc_typeck/src/typeck/expr/literals.rs
@@ -125,8 +125,9 @@ pub fn type_expr_identifier<'input>(
         DiagnosticKind::UnableToResolveIdentifier(i.to_string()).error_in(expr_span)
     })?;
 
-    // Mark as used by adding the reference span and clone the type to return. Use a short-lived borrow
-    // so we don't keep the RefCell borrow across the function return.
+    // Mark as used by adding the reference span and clone the type to return. Use a
+    // short-lived borrow so we don't keep the RefCell borrow across the
+    // function return.
     let inferred_type = {
         let mut ty = ty_rc.borrow_mut();
         ty.referenced_spans.push(expr_span);

--- a/compiler/zrc_typeck/src/typeck/expr/literals.rs
+++ b/compiler/zrc_typeck/src/typeck/expr/literals.rs
@@ -125,11 +125,11 @@ pub fn type_expr_identifier<'input>(
         DiagnosticKind::UnableToResolveIdentifier(i.to_string()).error_in(expr_span)
     })?;
 
-    // Mark as used and clone the type to return. Use a short-lived borrow
+    // Mark as used by adding the reference span and clone the type to return. Use a short-lived borrow
     // so we don't keep the RefCell borrow across the function return.
     let inferred_type = {
         let mut ty = ty_rc.borrow_mut();
-        ty.used = true;
+        ty.referenced_spans.push(expr_span);
         ty.ty.clone()
     };
 

--- a/compiler/zrc_typeck/src/typeck/scope.rs
+++ b/compiler/zrc_typeck/src/typeck/scope.rs
@@ -130,7 +130,7 @@ impl<'input> ValueEntry<'input> {
 
     /// Create an unused value entry
     #[must_use]
-    pub fn unused(ty: TastType<'input>, declaration_span: Span) -> Self {
+    pub const fn unused(ty: TastType<'input>, declaration_span: Span) -> Self {
         Self {
             ty,
             referenced_spans: Vec::new(),

--- a/compiler/zrc_typeck/src/typeck/scope.rs
+++ b/compiler/zrc_typeck/src/typeck/scope.rs
@@ -111,29 +111,29 @@ where
 pub struct ValueEntry<'input> {
     /// The data type of the value
     pub ty: TastType<'input>,
-    /// Whether or not the value has been utilized (accessed) yet
-    /// This is used for unused variable warnings in zircop.
-    pub used: bool,
+    /// List of span locations where this value has been referenced.
+    /// This is used for unused variable warnings in zircop and for future use in a language server.
+    pub referenced_spans: Vec<Span>,
     /// The source span where this value was declared, for diagnostic purposes
     pub declaration_span: Span,
 }
 impl<'input> ValueEntry<'input> {
-    /// Create a used value entry
+    /// Create a used value entry with an initial reference span
     #[must_use]
-    pub const fn used(ty: TastType<'input>, declaration_span: Span) -> Self {
+    pub fn used(ty: TastType<'input>, declaration_span: Span, reference_span: Span) -> Self {
         Self {
             ty,
-            used: true,
+            referenced_spans: vec![reference_span],
             declaration_span,
         }
     }
 
     /// Create an unused value entry
     #[must_use]
-    pub const fn unused(ty: TastType<'input>, declaration_span: Span) -> Self {
+    pub fn unused(ty: TastType<'input>, declaration_span: Span) -> Self {
         Self {
             ty,
-            used: false,
+            referenced_spans: Vec::new(),
             declaration_span,
         }
     }

--- a/compiler/zrc_typeck/src/typeck/scope.rs
+++ b/compiler/zrc_typeck/src/typeck/scope.rs
@@ -112,7 +112,8 @@ pub struct ValueEntry<'input> {
     /// The data type of the value
     pub ty: TastType<'input>,
     /// List of span locations where this value has been referenced.
-    /// This is used for unused variable warnings in zircop and for future use in a language server.
+    /// This is used for unused variable warnings in zircop and for future use
+    /// in a language server.
     pub referenced_spans: Vec<Span>,
     /// The source span where this value was declared, for diagnostic purposes
     pub declaration_span: Span,

--- a/tools/zircop/src/lints/underscore_variable_used.rs
+++ b/tools/zircop/src/lints/underscore_variable_used.rs
@@ -28,8 +28,8 @@ use crate::{
 ///
 /// This lint recursively searches every block's associated
 /// [`BlockMetadata::scope`] for any variables with the
-/// [`zrc_typeck::typeck::ValueEntry::referenced_spans`] parameter non-empty and a name
-/// starting with an underscore.
+/// [`zrc_typeck::typeck::ValueEntry::referenced_spans`] parameter non-empty and
+/// a name starting with an underscore.
 pub struct UnderscoreVariableUsedLint;
 impl UnderscoreVariableUsedLint {
     /// Initialize this lint

--- a/tools/zircop/src/lints/underscore_variable_used.rs
+++ b/tools/zircop/src/lints/underscore_variable_used.rs
@@ -28,7 +28,7 @@ use crate::{
 ///
 /// This lint recursively searches every block's associated
 /// [`BlockMetadata::scope`] for any variables with the
-/// [`zrc_typeck::typeck::ValueEntry::used`] parameter set to `true` and a name
+/// [`zrc_typeck::typeck::ValueEntry::referenced_spans`] parameter non-empty and a name
 /// starting with an underscore.
 pub struct UnderscoreVariableUsedLint;
 impl UnderscoreVariableUsedLint {
@@ -68,7 +68,7 @@ impl<'input, 'gs> SemanticVisit<'input, 'gs> for Visit<'input> {
         // Check the current block's scope for underscore-used variables.
         for (var_name, var_entry_rc) in block.scope.values.iter() {
             let var_entry = var_entry_rc.borrow();
-            if var_entry.used
+            if !var_entry.referenced_spans.is_empty()
                 && var_name.starts_with('_')
                 && !self.reported_vars.contains(&var_name)
                 // Functions are also stored as variables in the scope, but

--- a/tools/zircop/src/lints/unused_variables.rs
+++ b/tools/zircop/src/lints/unused_variables.rs
@@ -23,7 +23,7 @@ use crate::{
 ///
 /// This lint recursively searches every block's associated
 /// [`BlockMetadata::scope`] for any variables with the
-/// [`zrc_typeck::typeck::ValueEntry::used`] parameter set to `false` and a name
+/// [`zrc_typeck::typeck::ValueEntry::referenced_spans`] parameter empty and a name
 /// that does not start with an underscore.
 pub struct UnusedVariablesLint;
 impl UnusedVariablesLint {
@@ -65,7 +65,7 @@ impl<'input, 'gs> SemanticVisit<'input, 'gs> for Visit<'input> {
         // `Rc<RefCell<...>>` so borrow the entry when inspecting it.
         for (var_name, var_entry_rc) in block.scope.values.iter() {
             let var_entry = var_entry_rc.borrow();
-            if !var_entry.used
+            if var_entry.referenced_spans.is_empty()
                 && !var_name.starts_with('_')
                 && !self.reported_vars.contains(&var_name)
                 // Functions are also stored as variables in the scope, but

--- a/tools/zircop/src/lints/unused_variables.rs
+++ b/tools/zircop/src/lints/unused_variables.rs
@@ -23,8 +23,8 @@ use crate::{
 ///
 /// This lint recursively searches every block's associated
 /// [`BlockMetadata::scope`] for any variables with the
-/// [`zrc_typeck::typeck::ValueEntry::referenced_spans`] parameter empty and a name
-/// that does not start with an underscore.
+/// [`zrc_typeck::typeck::ValueEntry::referenced_spans`] parameter empty and a
+/// name that does not start with an underscore.
 pub struct UnusedVariablesLint;
 impl UnusedVariablesLint {
     /// Initialize this lint


### PR DESCRIPTION
Refactor ValueEntry::used from a boolean flag to a Vec<Span> that tracks all locations where a value has been referenced. This change enables future use in a language server for finding all references to a variable.

## Changes
- Replace `used: bool` field with `referenced_spans: Vec<Span>` in ValueEntry
- Update `used()` method to accept a reference_span parameter
- Update `unused()` method to initialize an empty Vec
- Update `type_expr_identifier` to push reference spans instead of setting used flag
- Update `unused_variables` lint to check `referenced_spans.is_empty()`
- Update `underscore_variable_used` lint to check `!referenced_spans.is_empty()`

Closes #511

Co-authored-by: @thetayloredman

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Variable-usage tracking now records all reference locations (spans) rather than a simple used flag, enabling richer diagnostics and tooling integration.
  * Lint logic updated to base unused/underscore-variable checks on actual reference locations.

* **Bug Fixes**
  * Reduces false positives by excluding function variables from underscore-prefixed usage reports and more accurately detecting truly unused variables.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->