### PR TITLE
Add include directory into build output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 lcov.info
 .direnv
 /examples/**/out
+/result

--- a/flake.nix
+++ b/flake.nix
@@ -49,8 +49,10 @@
               libffi
               libxml2
             ];
-
-            LLVM_SYS_201_PREFIX = llvm.llvm.dev;
+            postInstall = ''
+		cp -r $src/include $out
+            '';
+	    LLVM_SYS_201_PREFIX = llvm.llvm.dev;
          };
 
         packages.default = self.packages.${system}.zrc;

--- a/result
+++ b/result
@@ -1,1 +1,0 @@
-/nix/store/fkmsra3r2s8m5pwacycz5ab0n26s4vhf-rust-workspace-unknown

--- a/result
+++ b/result
@@ -1,0 +1,1 @@
+/nix/store/fkmsra3r2s8m5pwacycz5ab0n26s4vhf-rust-workspace-unknown


### PR DESCRIPTION
This should copy the `include` directory into the nix-build `result` directory, to hopefully have a static include path when we ultimately install the zirco compiler in the future. Minor change, but beneficial in the long run. May be helpful for having a standard zirco library in the future.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated build configuration for improved package assembly
  * Updated repository configuration to exclude build artifacts

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->