### PR TITLE
Add remove function to stdio bindings

### DIFF
--- a/include/stdio.zh
+++ b/include/stdio.zh
@@ -16,4 +16,4 @@ fn snprintf(a: *u8, b: usize, c: *u8, ...) -> i32;
 fn fopen(filename: *u8, mode: *u8) -> *FILE;
 fn fclose(fptr: *FILE) -> i32;
 fn fprintf(fptr: *FILE, a: *u8, ...) -> i32;
-fn fread(buffer: *void, size: usize, count: usize, stream: *FILE);
+fn fread(buffer: *void, size: usize, count: usize, stream: *FILE) -> usize;

--- a/include/stdio.zh
+++ b/include/stdio.zh
@@ -17,3 +17,4 @@ fn fopen(filename: *u8, mode: *u8) -> *FILE;
 fn fclose(fptr: *FILE) -> i32;
 fn fprintf(fptr: *FILE, a: *u8, ...) -> i32;
 fn fread(buffer: *void, size: usize, count: usize, stream: *FILE) -> usize;
+fn remove(filename: *u8) -> i32;


### PR DESCRIPTION
This one-liner should add the C standard library remove function to stdio. It should also fix a bug with the return of the fread function, to actually have the proper return value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new file removal function to the standard library.

* **Updates**
  * Clarified return type specification for the file read operation to ensure consistent behavior and better type safety.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->