### PR TITLE
fix(codegen): implement two-pass generation to resolve ICE #552

### DIFF
--- a/compiler/zrc_codegen/src/program.rs
+++ b/compiler/zrc_codegen/src/program.rs
@@ -6,7 +6,6 @@
 //! to machine code.
 
 use inkwell::{
-    OptimizationLevel,
     context::Context,
     debug_info::{AsDIScope, DISubprogram, DWARFEmissionKind, DWARFSourceLanguage},
     memory_buffer::MemoryBuffer,
@@ -17,6 +16,7 @@ use inkwell::{
     },
     types::{AnyType, BasicMetadataTypeEnum, BasicTypeEnum},
     values::{BasicValue, BasicValueEnum, FunctionValue},
+    OptimizationLevel,
 };
 use zrc_typeck::tast::{
     stmt::{ArgumentDeclaration, TypedDeclaration},

--- a/compiler/zrc_codegen/src/program.rs
+++ b/compiler/zrc_codegen/src/program.rs
@@ -348,31 +348,30 @@ fn cg_program_without_optimization<'ctx>(
 
                 let is_variadic = parameters.value().is_variadic();
 
-                // If it has a body, it's a normal function. If None, it's extern.
-                // Check if the body exists
-                if body.is_some() {
-                    let (fn_value, _fn_subprogram) = cg_init_fn(
+                // Calculate the function value (using if as an expression)
+                let fn_value = if body.is_some() {
+                    // Extract just the value (.0) from the tuple returned by cg_init_fn
+                    cg_init_fn(
                         &unit,
                         name.value(),
                         line_lookup.lookup_from_index(span.start()).line,
                         return_type.value(),
                         &arg_types,
                         is_variadic,
-                    );
-                    global_scope
-                        .insert(name.value(), fn_value.as_global_value().as_pointer_value());
+                    )
+                    .0
                 } else {
-                    // Handle extern functions (no body)
-                    let fn_value = cg_init_extern_fn(
+                    cg_init_extern_fn(
                         &unit,
                         name.value(),
                         return_type.value(),
                         &arg_types,
                         is_variadic,
-                    );
-                    global_scope
-                        .insert(name.value(), fn_value.as_global_value().as_pointer_value());
-                }
+                    )
+                };
+
+                // Insert into scope once
+                global_scope.insert(name.value(), fn_value.as_global_value().as_pointer_value());
             }
             TypedDeclaration::GlobalLetDeclaration(declarations) => {
                 // Generate global variables immediately (they don't have bodies)

--- a/compiler/zrc_typeck/src/typeck/scope.rs
+++ b/compiler/zrc_typeck/src/typeck/scope.rs
@@ -163,8 +163,6 @@ impl Default for ValueCtx<'_> {
 }
 impl<'input> ValueCtx<'input> {
     /// Create a new empty [`ValueScope`].
-    // Does not impl [Default] because a default would be misleading: the "empty" scope is more
-    // accurate.
     #[must_use]
     pub fn new() -> Self {
         Self {

--- a/compiler/zrc_typeck/src/typeck/scope.rs
+++ b/compiler/zrc_typeck/src/typeck/scope.rs
@@ -156,6 +156,11 @@ pub struct ValueCtx<'input> {
     /// sibling scopes.
     mappings: HashMap<&'input str, Rc<RefCell<ValueEntry<'input>>>>,
 }
+impl Default for ValueCtx<'_> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 impl<'input> ValueCtx<'input> {
     /// Create a new empty [`ValueScope`].
     // Does not impl [Default] because a default would be misleading: the "empty" scope is more


### PR DESCRIPTION
Closes #552 

**The Bug:**
The compiler panicked when a function (`main`) called another function (`f`) that was defined *later* in the file. The single-pass code generator tried to generate the call before `f` was registered in the scope.

**The Fix:**
Split `cg_program_without_optimization` into two passes:
1. **Pass 1:** Iterates through declarations to register all function prototypes and globals in the `CgScope`.
2. **Pass 2:** Iterates again to generate the function bodies.

**Other Changes:**
- Fixed a clippy lint in `zrc_typeck` (missing `Default` impl) that was preventing local builds.

**Verification:**
- Verified that the reproduction code from #552 now compiles to LLVM IR successfully.
- Ran `cargo clippy` and `cargo fmt` to ensure code quality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Adopted a two-pass code generation flow: prototypes and globals are now registered first, with function bodies generated in a dedicated second pass — improving compilation organization and reliability.
  * Globals and externs are registered earlier, with constant initializers handled during registration.
  * Simplified context initialization by adding a default-construction path for the value context to improve initialization consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->