### PR TITLE
Fix typo in Match Statement link in SPEC.md

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -62,7 +62,7 @@ Version 0.1.0 (Draft)
     - [Continue Statement](#511-continue-statement)
     - [Return Statement](#512-return-statement)
     - [Switch Statement](#513-switch-statement)
-    - [Match Statement](#514-match-statement]
+    - [Match Statement](#514-match-statement)
     - [Optimization Hints](#515-optimization-hints)
         - [Unreachable Statement](#5151-unreachable-statement)
 6. [Declarations](#6-declarations)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed a broken Markdown link syntax in the documentation's Table of Contents entry to ensure proper navigation and accessibility for users referencing the specification.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->