### PR TITLE
Add array literals to Zirco

### DIFF
--- a/compiler/zrc_codegen/src/expr.rs
+++ b/compiler/zrc_codegen/src/expr.rs
@@ -125,5 +125,6 @@ pub(crate) fn cg_expr<'ctx, 'input, 'a>(
         TypedExprKind::Cast(x, ty) => misc::cg_cast(ce, x, &ty),
         TypedExprKind::SizeOf(ty) => misc::cg_size_of(ce, &ty),
         TypedExprKind::StructConstruction(fields) => misc::cg_struct_construction(ce, &fields),
+        TypedExprKind::ArrayLiteral(elements) => literals::cg_array_literal(ce, elements),
     }
 }

--- a/compiler/zrc_codegen/src/expr/literals.rs
+++ b/compiler/zrc_codegen/src/expr/literals.rs
@@ -1,6 +1,7 @@
 //! code generation for literal expressions
 
 use inkwell::{
+    AddressSpace,
     types::StringRadix,
     values::{BasicValue, BasicValueEnum},
 };
@@ -136,6 +137,7 @@ pub fn cg_array_literal<'ctx, 'input>(
         .expect("array allocation should have compiled successfully");
 
     // Extract element type so we can GEP into elements
+    #[expect(clippy::wildcard_enum_match_arm)]
     let element_type = match &inferred_type {
         Type::Array { element_type, .. } => element_type.as_ref(),
         _ => panic!("array literal has non-array inferred type"),
@@ -145,7 +147,6 @@ pub fn cg_array_literal<'ctx, 'input>(
 
     // Bitcast the `ptr to [N x T]` into a `ptr to T` so we can index elements
     // with a single index. This avoids mismatches in the GEP element type.
-    use inkwell::AddressSpace;
 
     // LLVM 15+ uses opaque pointers; use the context's pointer type as the
     // destination for the pointer cast rather than trying to construct a
@@ -160,6 +161,7 @@ pub fn cg_array_literal<'ctx, 'input>(
         let el_val = unpack!(bb = super::cg_expr(cg, bb, el));
 
         // Use pointer-sized index for indexing
+        #[expect(clippy::as_conversions)]
         let idx_const = cg
             .ctx
             .ptr_sized_int_type(&cg.target_machine.get_target_data(), None)

--- a/compiler/zrc_codegen/src/expr/literals.rs
+++ b/compiler/zrc_codegen/src/expr/literals.rs
@@ -4,7 +4,7 @@ use inkwell::{
     types::StringRadix,
     values::{BasicValue, BasicValueEnum},
 };
-use zrc_typeck::tast::expr::{NumberLiteral, Place, PlaceKind, StringTok, ZrcString};
+use zrc_typeck::tast::expr::{NumberLiteral, Place, PlaceKind, StringTok, TypedExpr, ZrcString};
 use zrc_utils::span::Spannable;
 
 use super::place::cg_place;
@@ -113,6 +113,81 @@ pub fn cg_identifier<'ctx, 'input>(
     bb.and(reg.as_basic_value_enum())
 }
 
+/// Generate LLVM IR for an array literal
+pub fn cg_array_literal<'ctx, 'input>(
+    CgExprArgs {
+        cg,
+        mut bb,
+        inferred_type,
+        ..
+    }: CgExprArgs<'ctx, 'input, '_>,
+    elements: Vec<TypedExpr<'input>>,
+) -> BasicBlockAnd<'ctx, BasicValueEnum<'ctx>> {
+    use zrc_typeck::tast::ty::Type;
+
+    // Obtain the LLVM array type
+    let array_basic = llvm_basic_type(&cg, &inferred_type).0;
+    let array_type = array_basic.into_array_type();
+
+    // Allocate on the stack
+    let array_ptr = cg
+        .builder
+        .build_alloca(array_type, "array_tmp")
+        .expect("array allocation should have compiled successfully");
+
+    // Extract element type so we can GEP into elements
+    let element_type = match &inferred_type {
+        Type::Array { element_type, .. } => element_type.as_ref(),
+        _ => panic!("array literal has non-array inferred type"),
+    };
+
+    let elem_basic = llvm_basic_type(&cg, element_type).0;
+
+    // Bitcast the `ptr to [N x T]` into a `ptr to T` so we can index elements
+    // with a single index. This avoids mismatches in the GEP element type.
+    use inkwell::AddressSpace;
+
+    // LLVM 15+ uses opaque pointers; use the context's pointer type as the
+    // destination for the pointer cast rather than trying to construct a
+    // pointer type from the `BasicTypeEnum` (which is deprecated / awkward).
+    let elem_ptr_type = cg.ctx.ptr_type(AddressSpace::default());
+    let array_as_elem_ptr = cg
+        .builder
+        .build_pointer_cast(array_ptr, elem_ptr_type, "array_as_elem_ptr")
+        .expect("pointer cast should succeed");
+
+    for (i, el) in elements.into_iter().enumerate() {
+        let el_val = unpack!(bb = super::cg_expr(cg, bb, el));
+
+        // Use pointer-sized index for indexing
+        let idx_const = cg
+            .ctx
+            .ptr_sized_int_type(&cg.target_machine.get_target_data(), None)
+            .const_int(i as u64, false);
+
+        // SAFETY: indices are known-good compile-time constants and the
+        // casted pointer points at the first element of the array allocation.
+        let gep = unsafe {
+            cg.builder
+                .build_gep(elem_basic, array_as_elem_ptr, &[idx_const], "elem_ptr")
+        }
+        .expect("building GEP for array element should succeed");
+
+        let gep_ptr = gep.as_basic_value_enum().into_pointer_value();
+
+        cg.builder
+            .build_store(gep_ptr, el_val)
+            .expect("store should have compiled successfully");
+    }
+
+    let reg = cg
+        .builder
+        .build_load(array_type, array_ptr, "array_val")
+        .expect("load should have compiled successfully");
+
+    bb.and(reg.as_basic_value_enum())
+}
+
 #[cfg(test)]
 mod tests {
     // Please read the "Common patterns in tests" section of crate::test_utils for
@@ -153,6 +228,16 @@ mod tests {
                 fn test() {
                     let a = 0b10_10;
                     let b = 0x1F_A4;
+                }
+            "});
+    }
+
+    #[test]
+    fn array_literal_generates_properly() {
+        cg_snapshot_test!(indoc! {"
+                fn test() -> i32 {
+                    let x = [1i32, 2i32, 3i32];
+                    return x[1usize];
                 }
             "});
     }

--- a/compiler/zrc_codegen/src/expr/misc.rs
+++ b/compiler/zrc_codegen/src/expr/misc.rs
@@ -241,7 +241,8 @@ pub fn cg_struct_construction<'ctx, 'input>(
         | Type::Int
         | Type::Ptr(_)
         | Type::Fn(_)
-        | Type::Opaque(_) => {
+        | Type::Opaque(_)
+        | Type::Array { .. } => {
             unreachable!("struct construction should only be used with struct/union types")
         }
     }

--- a/compiler/zrc_codegen/src/expr/place.rs
+++ b/compiler/zrc_codegen/src/expr/place.rs
@@ -10,7 +10,6 @@
 //! by the `Place`.
 
 use inkwell::{
-    AddressSpace,
     basic_block::BasicBlock,
     debug_info::AsDIScope,
     values::{BasicValue, PointerValue},
@@ -89,18 +88,7 @@ pub fn cg_place<'ctx>(
                     .build_store(agg_alloc, ptr_val)
                     .expect("storing aggregate into temporary should succeed");
 
-                // Bitcast the allocation (pointer to aggregate) to an opaque
-                // pointer; we'll treat it as a pointer to the element and
-                // let GEP work from there. Use the context pointer type to
-                // avoid deprecated `.ptr_type` calls.
-                cg.builder
-                    .build_bit_cast(
-                        agg_alloc,
-                        cg.ctx.ptr_type(AddressSpace::default()),
-                        "array_field_ptr",
-                    )
-                    .expect("bitcast should succeed")
-                    .into_pointer_value()
+                agg_alloc
             };
 
             // SAFETY: This can segfault if indices are used incorrectly; the

--- a/compiler/zrc_codegen/src/expr/snapshots/zrc_codegen__expr__literals__tests__array_literal_generates_properly.snap
+++ b/compiler/zrc_codegen/src/expr/snapshots/zrc_codegen__expr__literals__tests__array_literal_generates_properly.snap
@@ -1,0 +1,45 @@
+---
+source: compiler/zrc_codegen/src/expr/literals.rs
+description: "fn test() -> i32 {\n    let x = [1i32, 2i32, 3i32];\n    return x[1usize];\n}\n"
+expression: resulting_ir
+---
+; ModuleID = 'test.zr'
+source_filename = "test.zr"
+
+define i32 @test() !dbg !3 {
+entry:
+  %let_x = alloca [3 x i32], align 4
+  %array_tmp = alloca [3 x i32], align 4, !dbg !7
+  %elem_ptr = getelementptr i32, ptr %array_tmp, i64 0, !dbg !10
+  store i32 1, ptr %elem_ptr, align 4, !dbg !10
+  %elem_ptr1 = getelementptr i32, ptr %array_tmp, i64 1, !dbg !11
+  store i32 2, ptr %elem_ptr1, align 4, !dbg !11
+  %elem_ptr2 = getelementptr i32, ptr %array_tmp, i64 2, !dbg !12
+  store i32 3, ptr %elem_ptr2, align 4, !dbg !12
+  %array_val = load [3 x i32], ptr %array_tmp, align 4, !dbg !12
+  store [3 x i32] %array_val, ptr %let_x, align 4, !dbg !13
+  %load = load ptr, ptr %let_x, align 8, !dbg !14
+  %gep = getelementptr i32, ptr %load, i64 1, !dbg !15
+  %load3 = load i32, ptr %gep, align 4, !dbg !15
+  ret i32 %load3, !dbg !15
+}
+
+!llvm.module.flags = !{!0}
+!llvm.dbg.cu = !{!1}
+
+!0 = !{i32 2, !"Debug Info Version", i32 3}
+!1 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "zrc test runner", isOptimized: false, flags: "zrc --fake-args", runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false)
+!2 = !DIFile(filename: "test.zr", directory: "/fake/path")
+!3 = distinct !DISubprogram(name: "test", linkageName: "test", scope: null, file: !2, line: 1, type: !4, scopeLine: 1, spFlags: DISPFlagDefinition, unit: !1)
+!4 = !DISubroutineType(types: !5)
+!5 = !{!6}
+!6 = !DIBasicType(name: "i32")
+!7 = !DILocation(line: 2, column: 13, scope: !8)
+!8 = distinct !DILexicalBlock(scope: !9, file: !2, line: 1, column: 18)
+!9 = distinct !DILexicalBlock(scope: !3, file: !2, line: 1, column: 18)
+!10 = !DILocation(line: 2, column: 14, scope: !8)
+!11 = !DILocation(line: 2, column: 20, scope: !8)
+!12 = !DILocation(line: 2, column: 26, scope: !8)
+!13 = !DILocation(line: 2, column: 9, scope: !8)
+!14 = !DILocation(line: 3, column: 12, scope: !8)
+!15 = !DILocation(line: 3, column: 14, scope: !8)

--- a/compiler/zrc_codegen/src/expr/snapshots/zrc_codegen__expr__literals__tests__array_literal_generates_properly.snap
+++ b/compiler/zrc_codegen/src/expr/snapshots/zrc_codegen__expr__literals__tests__array_literal_generates_properly.snap
@@ -18,10 +18,12 @@ entry:
   store i32 3, ptr %elem_ptr2, align 4, !dbg !12
   %array_val = load [3 x i32], ptr %array_tmp, align 4, !dbg !12
   store [3 x i32] %array_val, ptr %let_x, align 4, !dbg !13
-  %load = load ptr, ptr %let_x, align 8, !dbg !14
-  %gep = getelementptr i32, ptr %load, i64 1, !dbg !15
-  %load3 = load i32, ptr %gep, align 4, !dbg !15
-  ret i32 %load3, !dbg !15
+  %load = load [3 x i32], ptr %let_x, align 4, !dbg !14
+  %array_tmp3 = alloca [3 x i32], align 4, !dbg !15
+  store [3 x i32] %load, ptr %array_tmp3, align 4, !dbg !15
+  %gep = getelementptr i32, ptr %array_tmp3, i64 1, !dbg !15
+  %load4 = load i32, ptr %gep, align 4, !dbg !15
+  ret i32 %load4, !dbg !15
 }
 
 !llvm.module.flags = !{!0}

--- a/compiler/zrc_codegen/src/ty.rs
+++ b/compiler/zrc_codegen/src/ty.rs
@@ -213,6 +213,7 @@ pub fn llvm_basic_type<'ctx: 'a, 'a>(
                 .parse()
                 .expect("array size literal should be a valid integer");
 
+            #[expect(clippy::as_conversions, clippy::cast_possible_truncation)]
             let array_ty = elem_basic_ty
                 .array_type(size_val as u32)
                 .as_basic_type_enum();
@@ -227,16 +228,12 @@ pub fn llvm_basic_type<'ctx: 'a, 'a>(
                         .target_machine()
                         .get_target_data()
                         .get_bit_size(&elem_basic_ty);
-                    let total_bits = elem_bits * size_val as u64;
+                    let total_bits = elem_bits * size_val;
 
                     dbg_builder
                         .create_basic_type(
-                            &format!(
-                                "[{size}]{elem}",
-                                size = size.text_content(),
-                                elem = element_type.to_string()
-                            ),
-                            total_bits as u64,
+                            &format!("[{}]{element_type}", size.text_content(),),
+                            total_bits,
                             0,
                             0,
                         )

--- a/compiler/zrc_diagnostics/src/diagnostic_kind.rs
+++ b/compiler/zrc_diagnostics/src/diagnostic_kind.rs
@@ -128,6 +128,8 @@ pub enum DiagnosticKind {
     MainFunctionInvalidParameters,
     #[error("cannot use constant `{0}` as an lvalue")]
     AssignmentToConstant(String),
+    #[error("array size must be non-zero")]
+    ArraySizeZero,
 
     // PREPROCESSOR ERRORS
     #[error("unterminated include string")]

--- a/compiler/zrc_parser/src/ast/expr.rs
+++ b/compiler/zrc_parser/src/ast/expr.rs
@@ -249,6 +249,8 @@ pub enum ExprKind<'input> {
         Type<'input>,
         Spanned<Vec<Spanned<(Spanned<&'input str>, Expr<'input>)>>>,
     ),
+    /// Array literal: `[expr1, expr2, ...]`
+    ArrayLiteral(Vec<Expr<'input>>),
 
     /// Any numeric literal.
     NumberLiteral(NumberLiteral<'input>, Option<Type<'input>>),
@@ -308,7 +310,8 @@ impl ExprKind<'_> {
             | Self::CharLiteral(_)
             | Self::Identifier(_)
             | Self::BooleanLiteral(_)
-            | Self::StructConstruction(_, _) => Precedence::Primary,
+            | Self::StructConstruction(_, _)
+            | Self::ArrayLiteral(_) => Precedence::Primary,
         }
     }
 
@@ -492,6 +495,12 @@ impl std::fmt::Display for ExprKind<'_> {
             Self::CharLiteral(character) => write!(f, "'{character}'"),
             Self::Identifier(name) => write!(f, "{name}"),
             Self::BooleanLiteral(boolean) => write!(f, "{boolean}"),
+            Self::ArrayLiteral(els) => {
+                write!(f, "[")?;
+                let el_list: Vec<String> = els.iter().map(ToString::to_string).collect();
+                write!(f, "{}", el_list.join(", "))?;
+                write!(f, "]")
+            }
         }
     }
 }

--- a/compiler/zrc_parser/src/ast/ty.rs
+++ b/compiler/zrc_parser/src/ast/ty.rs
@@ -11,7 +11,7 @@ use zrc_utils::{
     spanned,
 };
 
-use crate::ast::stmt::ArgumentDeclarationList;
+use crate::{ast::stmt::ArgumentDeclarationList, lexer::NumberLiteral};
 
 /// A valid Zirco AST type
 #[derive(PartialEq, Eq, Debug, Clone, Display)]
@@ -52,6 +52,15 @@ pub enum TypeKind<'input> {
     /// A tagged union type
     #[display("enum {{ {_0} }}")]
     Enum(KeyTypeMapping<'input>),
+    /// An array type
+    #[display("[{size}]{element_type}")]
+    Array {
+        /// The element type
+        /// e.g. `i32` in `[4]i32`
+        element_type: Box<Type<'input>>,
+        /// The size integer
+        size: NumberLiteral<'input>,
+    },
     /// A function type
     /// `fn(params) -> return_type`
     #[display("fn({parameters}) -> {return_type}")]

--- a/compiler/zrc_parser/src/internal_parser.lalrpop
+++ b/compiler/zrc_parser/src/internal_parser.lalrpop
@@ -225,6 +225,11 @@ pub Type: Type<'input> = {
         Type(<>.map(TypeKind::Union)),
     Spanned<("enum" <KeyTypeMapping>)> =>
         Type(<>.map(TypeKind::Enum)),
+    Spanned<("[" <NUMBER> "]" <TypeOrParenthesizedType>)> =>
+        Type(<>.map(|(size, ty)| TypeKind::Array {
+            element_type: Box::new(ty),
+            size,
+        })),
 
     // We MANDATE the return type specification otherwise it creates a shift/reduce conflict with
     // `typeof (fn x -> y)`
@@ -409,6 +414,11 @@ Primary: Expr<'input> = {
         Expr(spanned!(s, ExprKind::StructConstruction(
             ty, 
             spanned!(s, fields.unwrap_or(Vec::new()), e, file_name)
+        ), e, file_name)),
+    // Array init : [ expr, expr, ... ]
+    <s:@L> "[" <elements:CommaSeparated<Assignment>?> "]" <e:@R> =>
+        Expr(spanned!(s, ExprKind::ArrayLiteral(
+            elements.unwrap_or(Vec::new())
         ), e, file_name)),
     "(" <Expr> ")" => <>,
 };

--- a/compiler/zrc_parser/src/lexer.rs
+++ b/compiler/zrc_parser/src/lexer.rs
@@ -236,6 +236,18 @@ impl<'input> NumberLiteral<'input> {
             Self::Binary(_) => 2,
         }
     }
+
+    /// Get the parsed value of this [`NumberLiteral`] as a `u128`
+    ///
+    /// # Panics
+    ///
+    /// Panics if the number literal could not be parsed as a `u128`.
+    #[must_use]
+    pub fn into_parsed_value(&self) -> u128 {
+        let text_without_underscores = self.text_content().replace('_', "");
+        u128::from_str_radix(&text_without_underscores, self.radix())
+            .expect("Number literal should have been valid")
+    }
 }
 
 /// Enum representing all of the result tokens in the Zirco lexer

--- a/compiler/zrc_typeck/src/tast/expr.rs
+++ b/compiler/zrc_typeck/src/tast/expr.rs
@@ -113,6 +113,8 @@ pub enum TypedExprKind<'input> {
 
     /// `new Type { field1: value1, field2: value2, ... }`
     StructConstruction(indexmap::IndexMap<&'input str, TypedExpr<'input>>),
+    /// `[value1, value2, value3, ... ]`
+    ArrayLiteral(Vec<TypedExpr<'input>>),
 
     /// Any numeric literal.
     NumberLiteral(NumberLiteral<'input>, Type<'input>),
@@ -209,7 +211,8 @@ impl TypedExprKind<'_> {
             | Self::CharLiteral(_)
             | Self::Identifier(_)
             | Self::BooleanLiteral(_)
-            | Self::StructConstruction(_) => Precedence::Primary,
+            | Self::StructConstruction(_)
+            | Self::ArrayLiteral(_) => Precedence::Primary,
         }
     }
 
@@ -369,6 +372,17 @@ impl Display for TypedExprKind<'_> {
             Self::CharLiteral(ch) => write!(f, "'{ch}'"),
             Self::Identifier(name) => write!(f, "{name}"),
             Self::BooleanLiteral(boolean) => write!(f, "{boolean}"),
+            Self::ArrayLiteral(items) => {
+                write!(
+                    f,
+                    "[{}]",
+                    items
+                        .iter()
+                        .map(ToString::to_string)
+                        .collect::<Vec<String>>()
+                        .join(", ")
+                )
+            }
         }
     }
 }

--- a/compiler/zrc_typeck/src/tast/ty.rs
+++ b/compiler/zrc_typeck/src/tast/ty.rs
@@ -9,6 +9,7 @@ use std::fmt::Display;
 
 use derive_more::Display;
 use indexmap::IndexMap;
+use zrc_parser::lexer::NumberLiteral;
 
 use super::stmt::ArgumentDeclarationList;
 
@@ -71,6 +72,13 @@ pub enum Type<'input> {
     Struct(IndexMap<&'input str, Self>),
     /// Union type literals. Ordered by declaration order.
     Union(IndexMap<&'input str, Self>),
+    /// Array type `[N]T`
+    Array {
+        /// The element type
+        element_type: Box<Self>,
+        /// The size integer
+        size: NumberLiteral<'input>,
+    },
     /// Opaque type placeholder used during type resolution for self-referential
     /// types. This is a temporary type that should be replaced with a void
     /// pointer (`*struct{}`) after the type definition is fully resolved.
@@ -117,6 +125,7 @@ impl Display for Type<'_> {
                     .join(", ")
             ),
             Self::Opaque(name) => write!(f, "{name}"),
+            Self::Array { element_type, size } => write!(f, "[{size}]{element_type}"),
         }
     }
 }
@@ -214,6 +223,19 @@ impl<'input> Type<'input> {
             && fields.is_empty()
         {
             // Target is *struct{}, allow implicit cast from any *T
+            return true;
+        }
+
+        // Allow arrays to implicitly cast to pointers to their element type
+        if let (
+            Type::Array {
+                element_type: from_element,
+                ..
+            },
+            Type::Ptr(to_pointee),
+        ) = (self, target)
+            && **to_pointee == **from_element
+        {
             return true;
         }
 
@@ -346,7 +368,8 @@ mod tests {
             | Type::Ptr(_)
             | Type::Fn(_)
             | Type::Union(_)
-            | Type::Opaque(_) => panic!("unit should be an empty struct"),
+            | Type::Opaque(_)
+            | Type::Array { .. } => panic!("unit should be an empty struct"),
         }
     }
 

--- a/compiler/zrc_typeck/src/typeck/expr.rs
+++ b/compiler/zrc_typeck/src/typeck/expr.rs
@@ -79,6 +79,7 @@ pub fn type_expr<'input>(
         ExprKind::StructConstruction(ty, fields) => {
             misc::type_expr_struct_construction(scope, expr_span, ty, &fields)?
         }
+        ExprKind::ArrayLiteral(fields) => misc::type_expr_array_literal(scope, expr_span, fields)?,
     })
 }
 

--- a/compiler/zrc_typeck/src/typeck/expr/access.rs
+++ b/compiler/zrc_typeck/src/typeck/expr/access.rs
@@ -40,11 +40,29 @@ pub fn type_expr_index<'input>(
         .error_in(offset_t.kind.span()));
     };
 
+    // Allow arrays to implicitly coerce to pointers to their element type.
     if let TastType::Ptr(points_to_ty) = ptr_t.inferred_type.clone() {
         Ok(TypedExpr {
             inferred_type: *points_to_ty,
             kind: TypedExprKind::Index(Box::new(ptr_t), Box::new(offset_final)).in_span(expr_span),
         })
+    } else if let TastType::Array { element_type, .. } = ptr_t.inferred_type.clone() {
+        // Try to coerce the array expression to a pointer to its element type
+        let target_ptr = TastType::Ptr(Box::new((*element_type).clone()));
+        let coerced_ptr = try_coerce_to(ptr_t, &target_ptr);
+
+        if let TastType::Ptr(points_to_ty) = coerced_ptr.inferred_type.clone() {
+            Ok(TypedExpr {
+                inferred_type: *points_to_ty,
+                kind: TypedExprKind::Index(Box::new(coerced_ptr), Box::new(offset_final))
+                    .in_span(expr_span),
+            })
+        } else {
+            Err(
+                DiagnosticKind::CannotIndexIntoNonPointer(coerced_ptr.inferred_type.to_string())
+                    .error_in(expr_span),
+            )
+        }
     } else {
         Err(
             DiagnosticKind::CannotIndexIntoNonPointer(ptr_t.inferred_type.to_string())

--- a/compiler/zrc_typeck/src/typeck/expr/literals.rs
+++ b/compiler/zrc_typeck/src/typeck/expr/literals.rs
@@ -39,9 +39,7 @@ pub fn type_expr_number_literal<'input>(
 
     // Check the bounds of the number literal
     // Note: We skip usize/isize since their size is platform-dependent
-    let text_without_underscores = n.text_content().replace('_', "");
-    let parsed_value = u128::from_str_radix(&text_without_underscores, n.radix())
-        .expect("Number literal should have been valid");
+    let parsed_value = n.into_parsed_value();
 
     // Check bounds based on type
     #[expect(clippy::wildcard_enum_match_arm)]

--- a/compiler/zrc_typeck/src/typeck/ty.rs
+++ b/compiler/zrc_typeck/src/typeck/ty.rs
@@ -19,7 +19,6 @@ use crate::tast::{
 /// # Errors
 /// Errors if the identifier is not found in the type scope or a key is
 /// double-defined.
-#[expect(clippy::missing_panics_doc)]
 pub fn resolve_type<'input>(
     type_scope: &TypeCtx<'input>,
     ty: ParserType<'input>,
@@ -53,11 +52,7 @@ pub fn resolve_type<'input>(
             ]))
         }
         ParserTypeKind::Array { element_type, size } => {
-            let text_without_underscores = size.text_content().replace('_', "");
-            let parsed_value = u128::from_str_radix(&text_without_underscores, size.radix())
-                .expect("Number literal should have been valid");
-
-            if parsed_value == 0 {
+            if size.into_parsed_value() == 0 {
                 return Err(DiagnosticKind::ArraySizeZero.error_in(span));
             }
 
@@ -176,11 +171,7 @@ fn resolve_type_with_opaque<'input>(
             ]))
         }
         ParserTypeKind::Array { element_type, size } => {
-            let text_without_underscores = size.text_content().replace('_', "");
-            let parsed_value = u128::from_str_radix(&text_without_underscores, size.radix())
-                .expect("Number literal should have been valid");
-
-            if parsed_value == 0 {
+            if size.into_parsed_value() == 0 {
                 return Err(DiagnosticKind::ArraySizeZero.error_in(span));
             }
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -441,7 +441,7 @@ Array types are fixed-size sequences of elements of a specified type.
 [N]T
 ```
 
-Where `N` is a positive integer representing the number of elements, and `T` is the element type.
+Where `N` is a positive integer (gt 0) representing the number of elements, and `T` is the element type.
 
 **Example**:
 
@@ -578,6 +578,8 @@ Zirco allows the following implicit type conversions:
     let arr: [5]i32 = [1, 2, 3, 4, 5];
     let ptr: *i32 = arr;  // Implicit conversion from [5]i32 to *i32
     ```
+
+**Semantics**: The pointer points to the first element of the array. The conversion applies in assignment, function argument, and indexing contexts.
 
 Note: Implicit conversions only apply in specific contexts such as function arguments. Most operations require explicit type matching or explicit casts using the `as` operator.
 
@@ -915,6 +917,19 @@ let arr = [1, 2, 3, 4, 5];
 -   Elements are evaluated in order
 -   Produces a fixed-size array value
 -   Requires at least one element
+
+**Type Specification**:
+
+-   Type can be inferred from element types: `let arr = [1, 2, 3];` infers `[3]i32`
+-   Type can be explicitly specified (syntax to be defined by implementation)
+-   All elements must have the same type; implicit conversions may apply in specific contexts
+
+**Example with Type Inference**:
+
+```zirco
+let arr1 = [1, 2, 3, 4, 5];        // inferred as [5]i32
+let arr2: [5]i32 = [1, 2, 3, 4, 5]; // explicit type annotation
+```
 
 ### 4.18 Increment and Decrement Expressions
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -24,11 +24,12 @@ Version 0.1.0 (Draft)
     - [Type Syntax](#32-type-syntax)
     - [Primitive Types](#33-primitive-types)
     - [Pointer Types](#34-pointer-types)
-    - [Struct Types](#35-struct-types)
-    - [Union Types](#36-union-types)
-    - [Enum Types](#37-enum-types)
-    - [Type Aliases](#38-type-aliases)
-    - [Type Inference and Implicit Conversions](#39-type-inference-and-implicit-conversions)
+    - [Array Types](#35-array-types)
+    - [Struct Types](#36-struct-types)
+    - [Union Types](#37-union-types)
+    - [Enum Types](#38-enum-types)
+    - [Type Aliases](#39-type-aliases)
+    - [Type Inference and Implicit Conversions](#310-type-inference-and-implicit-conversions)
 4. [Expressions](#4-expressions)
     - [Expression Overview](#41-expression-overview)
     - [Operator Precedence](#42-operator-precedence)
@@ -46,7 +47,8 @@ Version 0.1.0 (Draft)
     - [Ternary Conditional Expression](#414-ternary-conditional-expression)
     - [Sizeof Expressions](#415-sizeof-expressions)
     - [Comma Expression](#416-comma-expression)
-    - [Increment and Decrement Expressions](#417-increment-and-decrement-expressions)
+    - [Array Construction Expression](#417-array-construction-expression)
+    - [Increment and Decrement Expressions](#418-increment-and-decrement-expressions)
 5. [Statements](#5-statements)
     - [Statement Overview](#51-statement-overview)
     - [Expression Statements](#52-expression-statements)
@@ -429,7 +431,26 @@ A function pointer is represented as a pointer to a function type:
 *(fn(a: i32, b: *u8) -> bool)  // pointer to function taking (i32, *u8) and returning bool
 ```
 
-### 3.5 Struct Types
+### 3.5 Array Types
+
+Array types are fixed-size sequences of elements of a specified type.
+
+**Array Syntax**:
+
+```zirco
+[N]T
+```
+
+Where `N` is a positive integer representing the number of elements, and `T` is the element type.
+
+**Example**:
+
+```zirco
+[5]i32        // array of 5 i32 elements
+[10]*u8      // array of 10 pointers to u8
+```
+
+### 3.6 Struct Types
 
 Structs are product types that group named fields together:
 
@@ -471,7 +492,7 @@ struct Company {
 }
 ```
 
-### 3.6 Union Types
+### 3.7 Union Types
 
 Unions are sum types where a value can be one of several different types:
 
@@ -499,7 +520,7 @@ type Value = union { i: i32, f: f32 };
 -   Fields are accessed using the `.` operator
 -   Reading an inactive field is undefined behavior
 
-### 3.7 Enum Types
+### 3.8 Enum Types
 
 Enums are tagged unions, or sum types where a value must be _verified_ to be one of
 several types before use.
@@ -516,7 +537,7 @@ union MyUnion {
 
 These variants are used in the match statements.
 
-### 3.8 Type Aliases
+### 3.9 Type Aliases
 
 Type aliases create alternate names for existing types:
 
@@ -530,7 +551,7 @@ type ComplexStruct = struct { a: i32, b: *u8 };
 
 Type aliases are transparent - they create a new name but not a new type. The alias and the original type are interchangeable.
 
-### 3.9 Type Inference and Implicit Conversions
+### 3.10 Type Inference and Implicit Conversions
 
 **Type Inference**:
 
@@ -550,6 +571,13 @@ Zirco allows the following implicit type conversions:
     ```
 
 2. **Untyped Integer Literals**: Integer literals without a type suffix can be implicitly converted to any integer type when used in contexts where the target type is known (implementation-defined behavior).
+
+3. **Arrays to Pointers**: An array type `[N]T` can be implicitly converted to a pointer type `*T` when used in expressions.
+
+    ```zirco
+    let arr: [5]i32 = [1, 2, 3, 4, 5];
+    let ptr: *i32 = arr;  // Implicit conversion from [5]i32 to *i32
+    ```
 
 Note: Implicit conversions only apply in specific contexts such as function arguments. Most operations require explicit type matching or explicit casts using the `as` operator.
 
@@ -871,7 +899,24 @@ let x = (a = 5, b = 10, a + b);  // x is 15
 -   Result is the value of the rightmost expression
 -   Primarily used for side effects
 
-### 4.17 Increment and Decrement Expressions
+### 4.17 Array Construction Expression
+
+Array construction creates an array from a list of expressions:
+
+```zirco
+let arr = [1, 2, 3, 4, 5];
+```
+
+**Rules**:
+
+-   All elements must be of the same type
+-   The resulting array type is `[N]T` where `N` is the number
+    of elements and `T` is the element type
+-   Elements are evaluated in order
+-   Produces a fixed-size array value
+-   Requires at least one element
+
+### 4.18 Increment and Decrement Expressions
 
 Zirco supports both prefix and postfix increment and decrement operators for integer types.
 

--- a/tools/zircop/src/visit.rs
+++ b/tools/zircop/src/visit.rs
@@ -43,6 +43,11 @@ pub trait SyntacticVisit<'input> {
                 self.visit_expr(lhs.as_ref());
                 self.visit_expr(rhs.as_ref());
             }
+            AstExprKind::ArrayLiteral(items) => {
+                for item in items {
+                    self.visit_expr(item);
+                }
+            }
             AstExprKind::Call(func, args) => {
                 self.visit_expr(func.as_ref());
                 for arg in args.value() {
@@ -347,6 +352,11 @@ pub trait SemanticVisit<'input, 'gs> {
                 self.visit_place(place.as_ref());
                 for arg in args {
                     self.visit_tc_expr(arg);
+                }
+            }
+            TcExprKind::ArrayLiteral(items) => {
+                for item in items {
+                    self.visit_tc_expr(item);
                 }
             }
             TcExprKind::Ternary(cond, if_true, if_false) => {


### PR DESCRIPTION
WIP
fixes #399


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Array types with syntax [N]T and array literals, e.g., [1, 2, 3]
  * Indexing works for arrays and for aggregate values that decay to pointers

* **Type Checking / Diagnostics**
  * Arrays are first-class: non-empty, homogeneous elements enforced
  * New diagnostic for zero-sized arrays

* **Code Generation**
  * Array literals produce correct runtime representation; arrays can decay to element pointers

* **Documentation**
  * Spec updated with Array Types and Array Construction Expression

* **Tools**
  * Visitors updated to traverse array literals in analyses

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->