### PR TITLE
feat!: remove need for `new` keyword in struct construction

### DIFF
--- a/compiler/zrc_parser/src/ast/expr.rs
+++ b/compiler/zrc_parser/src/ast/expr.rs
@@ -243,7 +243,7 @@ pub enum ExprKind<'input> {
     /// `sizeof(expr)`
     SizeOfExpr(Box<Expr<'input>>),
 
-    /// Struct construction: `new Type { field1: value1, field2: value2 }`
+    /// Struct construction: `Type { field1: value1, field2: value2 }`
     #[expect(clippy::type_complexity)]
     StructConstruction(
         Type<'input>,
@@ -469,7 +469,7 @@ impl std::fmt::Display for ExprKind<'_> {
             Self::SizeOfType(ty) => write!(f, "sizeof {ty}"),
             Self::SizeOfExpr(expr) => write!(f, "sizeof({expr})"),
             Self::StructConstruction(ty, fields) => {
-                write!(f, "new {ty} {{ ")?;
+                write!(f, "{ty} {{ ")?;
                 let field_list: Vec<String> = fields
                     .value()
                     .iter()

--- a/compiler/zrc_parser/src/internal_parser.lalrpop
+++ b/compiler/zrc_parser/src/internal_parser.lalrpop
@@ -241,6 +241,18 @@ TypeOrParenthesizedType: Type<'input> = {
     "(" <TypeOrParenthesizedType> ")" => <>,
 }
 
+// Only a subset of types can be constructed (structs, unions, enums, identifiers)
+// This prevents a grammar ambiguity as seen in #553
+ConstructibleType: Type<'input> = {
+    Spanned<IDENTIFIER> => Type(<>.map(|x| TypeKind::Identifier(x))),
+    Spanned<("struct" <KeyTypeMapping>)> => 
+        Type(<>.map(TypeKind::Struct)),
+    Spanned<("union" <KeyTypeMapping>)> =>
+        Type(<>.map(TypeKind::Union)),
+    Spanned<("enum" <KeyTypeMapping>)> =>
+        Type(<>.map(TypeKind::Enum)),
+}
+
 FlowStmt: StmtKind<'input> = {
     "continue" ";" => StmtKind::ContinueStmt,
     "break" ";" => StmtKind::BreakStmt,
@@ -404,10 +416,10 @@ Primary: Expr<'input> = {
     Spanned<"false"> => Expr(<>.map(|_| ExprKind::BooleanLiteral(false))),
     Spanned<("sizeof" <Type>)> => Expr(<>.map(|t| ExprKind::SizeOfType(t))),
     Spanned<("sizeof" "(" <Expr> ")")> => Expr(<>.map(|ex| ExprKind::SizeOfExpr(Box::new(ex)))),
-    // Struct construction: new Type { fields }
-    <s:@L> "new" <ty:Type> "{" <fields:StructFieldInitList?> "}" <e:@R> => 
+    // Struct construction: ID { fields }
+    <s:@L> <ty:ConstructibleType> "{" <fields:StructFieldInitList?> "}" <e:@R> => 
         Expr(spanned!(s, ExprKind::StructConstruction(
-            ty, 
+            ty,
             spanned!(s, fields.unwrap_or(Vec::new()), e, file_name)
         ), e, file_name)),
     "(" <Expr> ")" => <>,

--- a/compiler/zrc_parser/src/parser.rs
+++ b/compiler/zrc_parser/src/parser.rs
@@ -481,7 +481,7 @@ mod tests {
             #[test]
             fn struct_construction_with_named_type_parses() {
                 // Test: new Point { x: 1, y: 2 }
-                let result = parse_expr("new Point { x: 1, y: 2 }", "<test>");
+                let result = parse_expr("Point { x: 1, y: 2 }", "<test>");
                 assert!(
                     result.is_ok(),
                     "Failed to parse struct construction: {result:?}"
@@ -491,15 +491,15 @@ mod tests {
                 // Verify it's a struct construction by checking the display output
                 let output = format!("{expr}");
                 assert!(
-                    output.contains("new Point"),
-                    "Expected 'new Point' in output, got: {output}"
+                    output.contains("Point"),
+                    "Expected 'Point' in output, got: {output}"
                 );
             }
 
             #[test]
             fn struct_construction_with_empty_fields_parses() {
                 // Test: new EmptyStruct { }
-                let result = parse_expr("new EmptyStruct { }", "<test>");
+                let result = parse_expr("EmptyStruct { }", "<test>");
                 assert!(
                     result.is_ok(),
                     "Failed to parse empty struct construction: {result:?}"
@@ -509,7 +509,7 @@ mod tests {
             #[test]
             fn struct_construction_with_anonymous_type_parses() {
                 // Test: new struct { x: i32 } { x: 42 }
-                let result = parse_expr("new struct { x: i32 } { x: 42 }", "<test>");
+                let result = parse_expr("struct { x: i32 } { x: 42 }", "<test>");
                 assert!(
                     result.is_ok(),
                     "Failed to parse anonymous struct construction: {result:?}"
@@ -518,15 +518,15 @@ mod tests {
                 let expr = result.expect("Should have parsed successfully");
                 let output = format!("{expr}");
                 assert!(
-                    output.contains("new struct"),
-                    "Expected 'new struct' in output, got: {output}"
+                    output.contains("struct"),
+                    "Expected 'struct' in output, got: {output}"
                 );
             }
 
             #[test]
             fn struct_construction_with_multiple_fields_parses() {
                 // Test: new Color { r: 255, g: 128, b: 64 }
-                let result = parse_expr("new Color { r: 255, g: 128, b: 64 }", "<test>");
+                let result = parse_expr("Color { r: 255, g: 128, b: 64 }", "<test>");
                 assert!(
                     result.is_ok(),
                     "Failed to parse multi-field struct construction: {result:?}"
@@ -536,7 +536,7 @@ mod tests {
             #[test]
             fn struct_construction_with_expression_values_parses() {
                 // Test: new Point { x: 1 + 2, y: 3 * 4 }
-                let result = parse_expr("new Point { x: 1 + 2, y: 3 * 4 }", "<test>");
+                let result = parse_expr("Point { x: 1 + 2, y: 3 * 4 }", "<test>");
                 assert!(
                     result.is_ok(),
                     "Failed to parse struct construction with expressions: {result:?}"

--- a/examples/struct_construction/README.md
+++ b/examples/struct_construction/README.md
@@ -21,7 +21,7 @@ struct Point {
 }
 
 // Construct an instance using the new keyword
-let origin = new Point { x: 0, y: 0 };
+let origin = Point { x: 0, y: 0 };
 
 // Access fields
 let x_value = origin.x;
@@ -68,7 +68,7 @@ is 25
 
 **✅ Parser**: Fully implemented and tested  
 **✅ Type Checker**: Fully implemented  
-**✅ Code Generator**: Fully implemented  
+**✅ Code Generator**: Fully implemented
 
 All components are complete and working!
 
@@ -76,14 +76,13 @@ All components are complete and working!
 
 This example showcases the `new` keyword syntax which was chosen to avoid LALR(1) parser ambiguities. The syntax is:
 
-- `new TypeName { field1: value1, field2: value2, ... }`
+-   `new TypeName { field1: value1, field2: value2, ... }`
 
 This works for both named types (like `Point` and `Color` in this example) and anonymous struct types.
 
 The type checker ensures:
-- All required struct fields are initialized
-- Field types match the struct definition
-- No duplicate field initializations
-- The constructed type is indeed a struct or union
 
-
+-   All required struct fields are initialized
+-   Field types match the struct definition
+-   No duplicate field initializations
+-   The constructed type is indeed a struct or union

--- a/examples/struct_construction/main.zr
+++ b/examples/struct_construction/main.zr
@@ -24,27 +24,27 @@ fn main() -> i32 {
     
     // Named struct construction
     printf("\n1. Named struct construction:\n");
-    let origin = new Point { x: 0, y: 0 };
+    let origin = Point { x: 0, y: 0 };
     print_point(origin);
     
-    let center = new Point { x: 50, y: 50 };
+    let center = Point { x: 50, y: 50 };
     print_point(center);
     
     // Multiple field struct
     printf("\n2. Multi-field struct construction:\n");
-    let red = new Color { r: 255, g: 0, b: 0 };
+    let red = Color { r: 255, g: 0, b: 0 };
     print_color(red);
     
-    let green = new Color { r: 0, g: 255, b: 0 };
+    let green = Color { r: 0, g: 255, b: 0 };
     print_color(green);
     
-    let blue = new Color { r: 0, g: 0, b: 255 };
+    let blue = Color { r: 0, g: 0, b: 255 };
     print_color(blue);
     
     // Using constructed structs in expressions
     printf("\n3. Using struct fields in calculations:\n");
-    let p1 = new Point { x: 3, y: 4 };
-    let p2 = new Point { x: 6, y: 8 };
+    let p1 = Point { x: 3, y: 4 };
+    let p2 = Point { x: 6, y: 8 };
     
     let dx = p2.x - p1.x;
     let dy = p2.y - p1.y;

--- a/examples/union_enum_example/main.zr
+++ b/examples/union_enum_example/main.zr
@@ -38,19 +38,19 @@ fn print_color(c: Color) -> struct {} {
 
 fn main() -> i32 {
     // Create union with inline type
-    let val1 = new union { i: i32, f: i64 } { i: 42 };
+    let val1 = union { i: i32, f: i64 } { i: 42 };
     print_as_int(val1);
     
     // Create union with named type
-    let val2 = new Value { f: 1000000000 };
+    let val2 = Value { f: 1000000000 };
     print_as_long(val2);
     
     // Create enum with inline type
-    let color1 = new enum { Red: i32, Green: i32, Blue: i32 } { Red: 255 };
+    let color1 = enum { Red: i32, Green: i32, Blue: i32 } { Red: 255 };
     print_color(color1);
     
     // Create enum with named type
-    let color2 = new Color { Green: 128 };
+    let color2 = Color { Green: 128 };
     print_color(color2);
     
     return 0;


### PR DESCRIPTION
Previously we required structs to be constructed as `new T ...`, but
this is no longer needed. There were some grammar conflicts in #553 but
these were resolved by ONLY allowing constructions of typenames,
anonymous structs, anonymous unions, and anonymous enums.

This breaks all existing Zirco code that uses this.

Keeps `new` reserved for future use.


Fixes #553

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Streamlined struct, union, and enum construction syntax by removing the "new" keyword requirement. Objects now initialize using direct type expressions (e.g., `Point { x, y }` instead of `new Point { x, y }`), providing cleaner and more intuitive patterns for creating instances of structured types.

* **Documentation**
  * Updated all examples to reflect the new simplified construction syntax.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->