### PR TITLE
test: remove ignored test in #451

### DIFF
--- a/compiler/zrc_codegen/src/stmt/snapshots/zrc_codegen__stmt__switch__tests__enum_match_generates_as_expected.snap
+++ b/compiler/zrc_codegen/src/stmt/snapshots/zrc_codegen__stmt__switch__tests__enum_match_generates_as_expected.snap
@@ -1,0 +1,79 @@
+---
+source: compiler/zrc_codegen/src/stmt/switch.rs
+description: "enum VarInt {\n    I32: i32,\n    I64: i64,\n}\n\nfn f() -> VarInt;\nfn fi32(x: i32);\nfn fi64(x: i64);\n\nfn main() -> i32 {\n    let vi = f();\n\n    match (vi) {\n        I32: x => fi32(x);\n        I64: y => fi64(y);\n    }\n\n    return 0;\n}\n"
+expression: resulting_ir
+---
+; ModuleID = 'test.zr'
+source_filename = "test.zr"
+
+declare { i64, i64 } @f()
+
+declare {} @fi32(i32)
+
+declare {} @fi64(i64)
+
+define i32 @main() !dbg !3 {
+entry:
+  %let_y = alloca i64, align 8
+  %let_x = alloca i32, align 4
+  %let_vi = alloca { i64, i64 }, align 8
+  %call = call { i64, i64 } @f(), !dbg !7
+  store { i64, i64 } %call, ptr %let_vi, align 4, !dbg !10
+  %gep = getelementptr inbounds nuw { i64, i64 }, ptr %let_vi, i32 0, i32 0, !dbg !11
+  %load = load i64, ptr %gep, align 4, !dbg !11
+  switch i64 %load, label %default [
+    i64 0, label %case
+    i64 1, label %case1
+  ], !dbg !13
+
+default:                                          ; preds = %entry
+  unreachable, !dbg !14
+
+post:                                             ; preds = %case1, %case
+  ret i32 0, !dbg !16
+
+case:                                             ; preds = %entry
+  %gep2 = getelementptr inbounds nuw { i64, i64 }, ptr %let_vi, i32 0, i32 1, !dbg !17
+  %load3 = load i32, ptr %gep2, align 4, !dbg !17
+  store i32 %load3, ptr %let_x, align 4, !dbg !19
+  %load4 = load i32, ptr %let_x, align 4, !dbg !20
+  %call5 = call {} @fi32(i32 %load4), !dbg !20
+  br label %post, !dbg !20
+
+case1:                                            ; preds = %entry
+  %gep6 = getelementptr inbounds nuw { i64, i64 }, ptr %let_vi, i32 0, i32 1, !dbg !21
+  %load7 = load i64, ptr %gep6, align 4, !dbg !21
+  store i64 %load7, ptr %let_y, align 4, !dbg !23
+  %load8 = load i64, ptr %let_y, align 4, !dbg !24
+  %call9 = call {} @fi64(i64 %load8), !dbg !24
+  br label %post, !dbg !24
+}
+
+!llvm.module.flags = !{!0}
+!llvm.dbg.cu = !{!1}
+
+!0 = !{i32 2, !"Debug Info Version", i32 3}
+!1 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "zrc test runner", isOptimized: false, flags: "zrc --fake-args", runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false)
+!2 = !DIFile(filename: "test.zr", directory: "/fake/path")
+!3 = distinct !DISubprogram(name: "main", linkageName: "main", scope: null, file: !2, line: 10, type: !4, scopeLine: 10, spFlags: DISPFlagDefinition, unit: !1)
+!4 = !DISubroutineType(types: !5)
+!5 = !{!6}
+!6 = !DIBasicType(name: "i32")
+!7 = !DILocation(line: 11, column: 14, scope: !8)
+!8 = distinct !DILexicalBlock(scope: !9, file: !2, line: 10, column: 18)
+!9 = distinct !DILexicalBlock(scope: !3, file: !2, line: 10, column: 18)
+!10 = !DILocation(line: 11, column: 9, scope: !8)
+!11 = !DILocation(line: 13, column: 12, scope: !12)
+!12 = distinct !DILexicalBlock(scope: !8, file: !2, line: 13, column: 5)
+!13 = !DILocation(line: 15, column: 9, scope: !12)
+!14 = !DILocation(line: 13, column: 5, scope: !15)
+!15 = distinct !DILexicalBlock(scope: !12, file: !2, line: 13, column: 5)
+!16 = !DILocation(line: 18, column: 12, scope: !8)
+!17 = !DILocation(line: 13, column: 12, scope: !18)
+!18 = distinct !DILexicalBlock(scope: !12, file: !2, line: 13, column: 5)
+!19 = !DILocation(line: 14, column: 9, scope: !18)
+!20 = !DILocation(line: 14, column: 24, scope: !18)
+!21 = !DILocation(line: 13, column: 12, scope: !22)
+!22 = distinct !DILexicalBlock(scope: !12, file: !2, line: 13, column: 5)
+!23 = !DILocation(line: 15, column: 9, scope: !22)
+!24 = !DILocation(line: 15, column: 24, scope: !22)

--- a/compiler/zrc_codegen/src/stmt/switch.rs
+++ b/compiler/zrc_codegen/src/stmt/switch.rs
@@ -103,7 +103,6 @@ mod tests {
     use crate::cg_snapshot_test;
 
     #[test]
-    #[ignore = "currently fails due to #451"]
     fn enum_match_generates_as_expected() {
         cg_snapshot_test!(indoc! {"
             enum VarInt {


### PR DESCRIPTION
Fixes #451

This has been working for a long time and I have no idea why it wasn't
marked resolved


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Re-enabled a previously disabled test to ensure proper validation of enum matching code generation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->