### PR TITLE
configure ZIRCO_INCLUDE_PATH in dest

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -48,11 +48,21 @@
               pkg-config
               libffi
               libxml2
+              makeWrapper
             ];
+
+
             postInstall = ''
-		cp -r $src/include $out
+              cp -r $src/include $out/include
+              
+              wrapProgram $out/bin/zrc \
+                --set ZIRCO_INCLUDE_PATH $out/include
+
+              wrapProgram $out/bin/zircop \
+                --set ZIRCO_INCLUDE_PATH $out/include
             '';
-	    LLVM_SYS_201_PREFIX = llvm.llvm.dev;
+
+            LLVM_SYS_201_PREFIX = llvm.llvm.dev;
          };
 
         packages.default = self.packages.${system}.zrc;


### PR DESCRIPTION
The Nix flake was previously not properly configuring ZIRCO_INCLUDE_PATH for those who used it. This sets a default value as a program wrapper.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Build now includes a wrapper utility to support executable wrapping.
  * Install step places bundled include files alongside package outputs so they’re available at runtime.
  * Executables are wrapped to automatically set the include-path environment variable so they reliably find the bundled headers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->