### PR TITLE
Remove some dependencies in favor of self written code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1058,7 +1058,6 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 name = "zircop"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "clap",
  "derive_more",
  "indoc",
@@ -1086,9 +1085,7 @@ dependencies = [
 name = "zrc_cli"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "clap",
- "derive_more",
  "mimalloc",
  "zrc",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1095,7 +1095,6 @@ name = "zrc_codegen"
 version = "0.1.0"
 dependencies = [
  "cc",
- "indexmap",
  "indoc",
  "inkwell",
  "insta",
@@ -1141,7 +1140,6 @@ name = "zrc_typeck"
 version = "0.1.0"
 dependencies = [
  "derive_more",
- "indexmap",
  "zrc_diagnostics",
  "zrc_parser",
  "zrc_utils",

--- a/compiler/zrc_cli/Cargo.toml
+++ b/compiler/zrc_cli/Cargo.toml
@@ -9,7 +9,5 @@ path = "src/main.rs"
 
 [dependencies]
 zrc = { path = "../zrc" }
-anyhow = "1.0.82"
 clap = { version = "4.5.4", features = ["derive"] }
-derive_more = { version = "2.0.1", features = ["display"] }
 mimalloc = "0.1.48"

--- a/compiler/zrc_cli/src/cli.rs
+++ b/compiler/zrc_cli/src/cli.rs
@@ -1,9 +1,11 @@
 //! Command line interface declarations for the Zirco compiler
 
-use std::path::{Path, PathBuf};
+use std::{
+    fmt::Display,
+    path::{Path, PathBuf},
+};
 
 use clap::Parser;
-use derive_more::Display;
 use zrc::{OutputFormat, codegen::OptimizationLevel};
 
 /// The official Zirco compiler
@@ -88,39 +90,49 @@ impl From<FrontendOptLevel> for OptimizationLevel {
 /// The list of possible outputs `zrc` can emit in
 ///
 /// Usually you will want to use `llvm`.
-#[derive(Debug, Clone, clap::ValueEnum, PartialEq, Eq, Display)]
+#[derive(Debug, Clone, clap::ValueEnum, PartialEq, Eq)]
 pub enum FrontendOutputFormat {
     /// LLVM IR
-    #[display("llvm")]
     Llvm,
     /// The Zirco AST, in Rust-like format
-    #[display("ast-debug")]
     AstDebug,
     /// The Zirco AST, in Rust-like format with indentation
-    #[display("ast-debug-pretty")]
     AstDebugPretty,
     /// The Zirco AST, stringified to Zirco code again
     ///
     /// This usually looks like your code with a bunch of parenthesis added.
-    #[display("ast")]
     Ast,
     /// The Zirco TAST, in Rust-like format
-    #[display("tast-debug")]
     TastDebug,
     /// The Zirco TAST, in Rust-like format with indentation
-    #[display("tast-debug-pretty")]
     TastDebugPretty,
     /// The Zirco TAST, stringified to Zirco code again
     ///
     /// This usually looks like your code with a bunch of parenthesis added.
-    #[display("tast")]
     Tast,
     /// Assembly
-    #[display("asm")]
     Asm,
     /// Object file
-    #[display("object")]
     Object,
+}
+impl Display for FrontendOutputFormat {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::Llvm => "llvm",
+                Self::AstDebug => "ast-debug",
+                Self::AstDebugPretty => "ast-debug-pretty",
+                Self::Ast => "ast",
+                Self::TastDebug => "tast-debug",
+                Self::TastDebugPretty => "tast-debug-pretty",
+                Self::Tast => "tast",
+                Self::Asm => "asm",
+                Self::Object => "object",
+            }
+        )
+    }
 }
 
 impl From<FrontendOutputFormat> for OutputFormat {

--- a/compiler/zrc_codegen/Cargo.toml
+++ b/compiler/zrc_codegen/Cargo.toml
@@ -9,7 +9,6 @@ edition = "2024"
 inkwell = { git = "https://github.com/TheDan64/inkwell", version = "0.6.0", features = ["llvm20-1", "llvm20-1-prefer-static"] }
 zrc_typeck = { path = "../zrc_typeck" }
 zrc_utils = { path = "../zrc_utils" }
-indexmap = "2.2.6"
 
 [dev-dependencies]
 indoc = "2.0.5"

--- a/compiler/zrc_codegen/src/expr/misc.rs
+++ b/compiler/zrc_codegen/src/expr/misc.rs
@@ -1,11 +1,13 @@
 //! code generation for misc expressions
 
-use indexmap::IndexMap;
 use inkwell::{
     types::BasicType,
     values::{BasicValue, BasicValueEnum},
 };
-use zrc_typeck::tast::{expr::TypedExpr, ty::Type};
+use zrc_typeck::tast::{
+    expr::TypedExpr,
+    ty::{OrderedValueFields, Type},
+};
 use zrc_utils::span::Spanned;
 
 use crate::{
@@ -139,7 +141,7 @@ pub fn cg_struct_construction<'ctx, 'input>(
         inferred_type,
         ..
     }: CgExprArgs<'ctx, 'input, '_>,
-    fields: &IndexMap<&'input str, TypedExpr<'input>>,
+    fields: &OrderedValueFields<'input>,
 ) -> BasicBlockAnd<'ctx, BasicValueEnum<'ctx>> {
     match &inferred_type {
         Type::Struct(field_types) => {
@@ -192,7 +194,7 @@ pub fn cg_struct_construction<'ctx, 'input>(
 
             // Initialize the union with the provided field (if any)
             // In unions, all fields share the same memory space
-            for (field_name, _field_ty) in field_types {
+            for (field_name, _field_ty) in field_types.iter() {
                 if let Some(field_expr) = fields.get(field_name) {
                     // Evaluate the field value
                     let field_value = unpack!(bb = cg_expr(cg, bb, field_expr.clone()));

--- a/compiler/zrc_codegen/src/expr/place.rs
+++ b/compiler/zrc_codegen/src/expr/place.rs
@@ -88,7 +88,7 @@ pub fn cg_place<'ctx>(
                 let x_ty = llvm_basic_type(&cg, &x.inferred_type).0;
                 let prop_idx = contents
                     .iter()
-                    .position(|(got_key, _)| *got_key == prop.into_value())
+                    .position(|(got_key, _)| *got_key == *prop.into_value())
                     .expect("invalid struct field");
 
                 let x = unpack!(bb = cg_place(cg, bb, *x));

--- a/compiler/zrc_codegen/src/lib.rs
+++ b/compiler/zrc_codegen/src/lib.rs
@@ -52,7 +52,8 @@
     clippy::multiple_crate_versions,
     clippy::cargo_common_metadata,
     clippy::module_name_repetitions,
-    clippy::doc_comment_double_space_linebreaks
+    clippy::doc_comment_double_space_linebreaks,
+    clippy::boxed_local
 )]
 
 // Ordering matters! Declared here so other modules have access to `unpack!`

--- a/compiler/zrc_codegen/src/ty.rs
+++ b/compiler/zrc_codegen/src/ty.rs
@@ -179,7 +179,7 @@ pub fn llvm_basic_type<'ctx: 'a, 'a>(
             ctx.ctx()
                 .struct_type(
                     &fields
-                        .into_iter()
+                        .iter()
                         .map(|(_, key_ty)| llvm_basic_type(ctx, key_ty).0)
                         .collect::<Vec<_>>(),
                     false,
@@ -200,7 +200,7 @@ pub fn llvm_basic_type<'ctx: 'a, 'a>(
                         0,
                         None,
                         &fields
-                            .into_iter()
+                            .iter()
                             .map(|(key, key_ty)| {
                                 ctx.dbg_builder()
                                     .expect("we have DI")
@@ -231,7 +231,7 @@ pub fn llvm_basic_type<'ctx: 'a, 'a>(
         Type::Union(fields) => {
             // Determine which field has the largest size. This is what we will allocate.
             let largest_field = fields
-                .into_iter()
+                .iter()
                 .map(|(_, ty)| {
                     let ty = llvm_basic_type(ctx, ty).0;
                     let size = ctx.target_machine().get_target_data().get_bit_size(&ty);
@@ -260,7 +260,7 @@ pub fn llvm_basic_type<'ctx: 'a, 'a>(
                             0,
                             0,
                             &fields
-                                .into_iter()
+                                .iter()
                                 .map(|(_, ty)| llvm_basic_type(ctx, ty).1.expect("we have DI"))
                                 .collect::<Vec<_>>(),
                             0,

--- a/compiler/zrc_typeck/Cargo.toml
+++ b/compiler/zrc_typeck/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2024"
 
 [dependencies]
 derive_more = { version = "2.0.1", features = ["display"] }
-indexmap = "2.2.6"
 zrc_diagnostics = { path = "../zrc_diagnostics" }
 zrc_parser = { path = "../zrc_parser" }
 zrc_utils = { path = "../zrc_utils" }

--- a/compiler/zrc_typeck/src/tast/expr.rs
+++ b/compiler/zrc_typeck/src/tast/expr.rs
@@ -9,6 +9,7 @@ pub use zrc_parser::{
 use zrc_utils::span::Spanned;
 
 use super::ty::Type;
+use crate::tast::ty::OrderedValueFields;
 
 /// The left hand side of an assignment.
 #[derive(PartialEq, Debug, Clone)]
@@ -112,7 +113,7 @@ pub enum TypedExprKind<'input> {
     SizeOf(Type<'input>),
 
     /// `new Type { field1: value1, field2: value2, ... }`
-    StructConstruction(indexmap::IndexMap<&'input str, TypedExpr<'input>>),
+    StructConstruction(OrderedValueFields<'input>),
 
     /// `[expr1, expr2, expr3, ...]` - array literal
     ArrayLiteral(Vec<TypedExpr<'input>>),

--- a/compiler/zrc_typeck/src/typeck/expr.rs
+++ b/compiler/zrc_typeck/src/typeck/expr.rs
@@ -87,10 +87,8 @@ pub fn type_expr<'input>(
 
 #[cfg(test)]
 mod tests {
-
     use std::collections::HashMap;
 
-    use indexmap::IndexMap;
     use zrc_diagnostics::DiagnosticKind;
     use zrc_utils::spanned_test;
 
@@ -98,7 +96,7 @@ mod tests {
     use crate::{
         tast::{
             stmt::{ArgumentDeclaration, ArgumentDeclarationList},
-            ty::{Fn, Type as TastType},
+            ty::{Fn, OrderedTypeFields, Type as TastType},
         },
         typeck::scope::{GlobalScope, TypeCtx, ValueCtx},
     };
@@ -114,7 +112,7 @@ mod tests {
                 ("bool", TastType::Bool),
                 (
                     "s",
-                    TastType::Struct(IndexMap::from([("i8", TastType::I8)])),
+                    TastType::Struct(OrderedTypeFields::from(vec![("i8", TastType::I8)])),
                 ),
                 (
                     "get_bool",
@@ -160,7 +158,7 @@ mod tests {
             ])),
             types: TypeCtx::from_defaults_and_mappings(HashMap::from([(
                 "NonIntegerType",
-                TastType::Struct(IndexMap::from([])),
+                TastType::Struct(OrderedTypeFields::from(vec![])),
             )])),
             ..Default::default()
         };

--- a/compiler/zrc_typeck/src/typeck/expr/misc.rs
+++ b/compiler/zrc_typeck/src/typeck/expr/misc.rs
@@ -209,7 +209,6 @@ pub fn type_expr_struct_construction<'input>(
         Vec<zrc_utils::span::Spanned<(zrc_utils::span::Spanned<&'input str>, Expr<'input>)>>,
     >,
 ) -> Result<TypedExpr<'input>, Diagnostic> {
-    
     use zrc_parser::ast::ty::TypeKind as ParserTypeKind;
 
     // Check if we're constructing an enum before desugaring

--- a/compiler/zrc_typeck/src/typeck/scope.rs
+++ b/compiler/zrc_typeck/src/typeck/scope.rs
@@ -8,10 +8,7 @@ use std::{
 
 use zrc_utils::span::Span;
 
-use crate::tast::ty::{
-    FunctionDeclarationGlobalMetadata, OrderedTypeFields,
-    Type as TastType,
-};
+use crate::tast::ty::{FunctionDeclarationGlobalMetadata, OrderedTypeFields, Type as TastType};
 
 /// Represents a typing scope: a scope that contains the mapping from a type's
 /// name to its internal [`TastType`] representation.

--- a/compiler/zrc_typeck/src/typeck/scope.rs
+++ b/compiler/zrc_typeck/src/typeck/scope.rs
@@ -6,10 +6,12 @@ use std::{
     rc::Rc,
 };
 
-use indexmap::IndexMap;
 use zrc_utils::span::Span;
 
-use crate::tast::ty::{FunctionDeclarationGlobalMetadata, Type as TastType};
+use crate::tast::ty::{
+    FunctionDeclarationGlobalMetadata, OrderedTypeFields,
+    Type as TastType,
+};
 
 /// Represents a typing scope: a scope that contains the mapping from a type's
 /// name to its internal [`TastType`] representation.
@@ -20,7 +22,7 @@ pub struct TypeCtx<'input> {
 }
 /// All types namable in the global scope
 /// Returns all types namable in the global scope
-fn all_namable_types<'input>() -> [(&'input str, TastType<'input>); 12] {
+const fn all_namable_types<'input>() -> [(&'input str, TastType<'input>); 12] {
     [
         ("i8", TastType::I8),
         ("u8", TastType::U8),
@@ -33,7 +35,7 @@ fn all_namable_types<'input>() -> [(&'input str, TastType<'input>); 12] {
         ("isize", TastType::Isize),
         ("usize", TastType::Usize),
         ("bool", TastType::Bool),
-        ("void", TastType::Struct(IndexMap::new())),
+        ("void", TastType::Struct(OrderedTypeFields::new())),
     ]
 }
 impl<'input> TypeCtx<'input> {

--- a/compiler/zrc_utils/clippy.toml
+++ b/compiler/zrc_utils/clippy.toml
@@ -1,2 +1,2 @@
 absolute-paths-max-segments = 3
-allowed-idents-below-min-chars = [ "..", "f" ]
+allowed-idents-below-min-chars = [ "..", "f", "k", "v" ]

--- a/compiler/zrc_utils/src/lib.rs
+++ b/compiler/zrc_utils/src/lib.rs
@@ -51,4 +51,5 @@
 pub mod code_fmt;
 pub mod io;
 pub mod line_finder;
+pub mod ordered_fields;
 pub mod span;

--- a/compiler/zrc_utils/src/ordered_fields.rs
+++ b/compiler/zrc_utils/src/ordered_fields.rs
@@ -1,0 +1,88 @@
+//! The declaration ordered fields of a struct or union type or instantiation
+
+/// The declaration ordered fields of a struct or union type or instantiation
+#[derive(PartialEq, Eq, Debug, Clone)]
+pub struct OrderedFields<'input, T> {
+    /// The ordered fields
+    pub fields: Vec<(&'input str, T)>,
+}
+impl<'input, T> OrderedFields<'input, T> {
+    /// Creates a new, empty `OrderedFields`.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self { fields: Vec::new() }
+    }
+
+    /// Creates a new `OrderedFields` from the given fields.
+    #[must_use]
+    pub const fn from(fields: Vec<(&'input str, T)>) -> Self {
+        Self { fields }
+    }
+
+    /// Gets the number of fields.
+    #[must_use]
+    pub const fn len(&self) -> usize {
+        self.fields.len()
+    }
+
+    /// Checks if there are no fields.
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        self.fields.is_empty()
+    }
+
+    /// Returns `true` if the ordered fields contains the given key.
+    #[must_use]
+    pub fn contains_key(&self, key: &str) -> bool {
+        self.fields.iter().any(|(k, _)| k == &key)
+    }
+
+    /// Inserts a new field, or updates an existing one.
+    pub fn insert(&mut self, key: &'input str, value: T) {
+        for (k, v) in &mut self.fields {
+            if k == &key {
+                *v = value;
+                return;
+            }
+        }
+        self.fields.push((key, value));
+    }
+
+    /// Gets a reference to a field by key.
+    #[must_use]
+    pub fn get(&self, key: &str) -> Option<&T> {
+        for (k, v) in &self.fields {
+            if k == &key {
+                return Some(v);
+            }
+        }
+        None
+    }
+
+    /// Iterate over the fields in order.
+    pub fn iter(&self) -> impl Iterator<Item = (&'input str, &T)> {
+        self.fields.iter().map(|(k, v)| (*k, v))
+    }
+}
+impl<T> Default for OrderedFields<'_, T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+impl<'input, T> IntoIterator for OrderedFields<'input, T> {
+    type Item = (&'input str, T);
+    type IntoIter = std::vec::IntoIter<(&'input str, T)>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.fields.into_iter()
+    }
+}
+impl<'input, T> FromIterator<(&'input str, T)> for OrderedFields<'input, T> {
+    fn from_iter<I: IntoIterator<Item = (&'input str, T)>>(iter: I) -> Self {
+        let mut of = OrderedFields::new();
+        for (k, v) in iter {
+            of.insert(k, v);
+        }
+        of
+    }
+}

--- a/tools/zircop/Cargo.toml
+++ b/tools/zircop/Cargo.toml
@@ -14,7 +14,6 @@ zrc_utils = { path = "../../compiler/zrc_utils" }
 thiserror = "2.0.17"
 derive_more = { version = "2.0.1", features = ["display"] }
 clap = { version = "4.5.52", features = ["derive"] }
-anyhow = "1.0.100"
 
 [dev-dependencies]
 indoc = "2.0.7"

--- a/tools/zircop/src/main.rs
+++ b/tools/zircop/src/main.rs
@@ -55,15 +55,24 @@
 mod build_info;
 mod cli;
 
-use std::{path::Path, process};
+use std::{error::Error, fmt, path::Path, process};
 
-use anyhow::bail;
 use clap::Parser;
 use cli::Cli;
 use zircop::runner;
 use zrc_utils::io;
 
-fn main() -> anyhow::Result<()> {
+/// An error produced by the zircop CLI
+#[derive(Debug)]
+struct CliError(String);
+impl fmt::Display for CliError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+impl Error for CliError {}
+
+fn main() -> Result<(), Box<dyn Error>> {
     let cli = Cli::parse();
 
     if cli.version {
@@ -72,7 +81,7 @@ fn main() -> anyhow::Result<()> {
     }
 
     let Some(ref path) = cli.path else {
-        bail!("Error: No input file specified.");
+        return Err(Box::new(CliError("No input file specified.".into())));
     };
 
     let (directory_name, file_name, mut input) = io::open_input(path)?;

--- a/tools/zircop/src/visit.rs
+++ b/tools/zircop/src/visit.rs
@@ -365,7 +365,7 @@ pub trait SemanticVisit<'input, 'gs> {
             }
             TcExprKind::SizeOf(ty) => self.visit_tc_type(ty),
             TcExprKind::StructConstruction(fields) => {
-                for (_name, expr) in fields {
+                for (_name, expr) in fields.iter() {
                     self.visit_tc_expr(expr);
                 }
             }


### PR DESCRIPTION
- **repo: remove anyhow from user-facing code**
- **refactor: remove IndexMaps in favor of a vec<tuple>**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Switched to an ordered, deterministic representation for struct/union field storage and iteration.
  * Added a public ordered-fields utility to preserve insertion order for field collections.
  * Introduced clearer, consistent CLI error handling and reporting across command-line tools.

* **Chores**
  * Removed several unused dependencies to streamline builds and reduce bloat.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->