### PR TITLE
fix: properly use current symlink in hooks

### DIFF
--- a/hooks/zircon.sh
+++ b/hooks/zircon.sh
@@ -21,8 +21,8 @@ cp -r include/* "$ZIRCON_INCLUDE_DIR/"
 
 cat > "$ZIRCON_TOOLCHAIN_DIR/env.sh" << EOF
 #!/bin/sh
-export PATH="$ZIRCON_BIN_DIR:\$PATH"
-export ZIRCO_INCLUDE_PATH="$ZIRCON_INCLUDE_DIR:\$ZIRCO_INCLUDE_PATH"
+export PATH="$HOME/.zircon/toolchains/current/bin:\$PATH"
+export ZIRCO_INCLUDE_PATH="$HOME/.zircon/toolchains/current/include:\$ZIRCO_INCLUDE_PATH"
 EOF
 
 chmod +x "$ZIRCON_TOOLCHAIN_DIR/env.sh"


### PR DESCRIPTION
Previously env.sh would code in the current version to the shell env.
Using the current symlink allows for easier switches without need for a
new shell.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified toolchain environment variable configuration to resolve binary and include paths from user-local directory instead of generated toolchain directory.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->