### PR TITLE
repo: add nix hook for ZIRCO_INCLUDE_PATH

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -51,16 +51,11 @@
               makeWrapper
             ];
 
-
             postInstall = ''
               cp -r $src/include $out/include
-              
-              wrapProgram $out/bin/zrc \
-                --set ZIRCO_INCLUDE_PATH $out/include
-
-              wrapProgram $out/bin/zircop \
-                --set ZIRCO_INCLUDE_PATH $out/include
             '';
+
+            setupHook = ./hooks/nix.sh;
 
             LLVM_SYS_201_PREFIX = llvm.llvm.dev;
          };

--- a/hooks/nix.sh
+++ b/hooks/nix.sh
@@ -1,0 +1,11 @@
+# Nix setup hook for setting Zirco library paths for shells and builds that USE zrc
+
+# HACK: I can't seem to otherwise find $out from within this setup hook.
+# Get the directory of THIS script
+HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+
+# Assume include/ is positioned relative to the hook
+LIB_DIR="$HOOK_DIR/../include"
+
+# Now, we can finally inject into the environment!
+export ZIRCO_INCLUDE_PATH="${ZIRCO_INCLUDE_PATH:-}:$LIB_DIR"


### PR DESCRIPTION
This removes the default wrapper around zrc and instead provides a
setupHook to configure the include path.

This took me two hours to figure out but should be all set up to allow
the addition of future libraries.

Signed-off-by: Logan Devine <logan@zirco.dev>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored package build configuration to optimize library include path handling in Nix environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->