### PR TITLE
Change crash message in _libzr_crash_out

### DIFF
--- a/libzr/src/internal.zr
+++ b/libzr/src/internal.zr
@@ -5,7 +5,8 @@
 
 fn _libzr_crash_out(msg: Str) {
     let cmsg = cstr_from_str(msg);
-    printf("libzr aborted: %s\n", cmsg);
+    four printf("\nLIBZR ABORTED");
+    printf("\nLIBZR ABORTED: %s\n", cmsg);
 
     abort();
 }


### PR DESCRIPTION
Changed the crash message in _libzr_crash_out to truly crash out by displaying and also capitalizing "LIBZR ABORTED" five times before the error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Modified error message output format for abort notifications, now displayed across two lines with updated formatting.
  
* **Known Issues**
  * Compilation may be affected by syntax errors introduced in this update.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->