### PR TITLE
add rust-src extension to nix flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -26,8 +26,15 @@
       {
         devShells.default = pkgs.mkShell {
           buildInputs = with pkgs; [
-            rust-bin.stable.latest.default
-            rust-bin.nightly.latest.default
+            (rust-bin.stable.latest.default.override {
+              extensions = [ "rust-src" ];
+            })
+            (rust-bin.selectLatestNightlyWith (
+              toolchain:
+              toolchain.default.override {
+                extensions = [ "rust-src" ];
+              }
+            ))
             llvm.llvm
             llvm.libllvm
             llvm.clang


### PR DESCRIPTION
this makes it so rust-analyzer in vscode functions properly


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

- Development environment configuration updated: Rust source code is now automatically included and available in both stable and nightly toolchains within the development shell. This ensures all team members have access to necessary components for IDE integration, language server support, and development tooling without requiring additional configuration or manual setup steps.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->