### PR TITLE
chore(cg/deps): remove unused crate `cc`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1094,7 +1094,6 @@ dependencies = [
 name = "zrc_codegen"
 version = "0.1.0"
 dependencies = [
- "cc",
  "indoc",
  "inkwell",
  "insta",

--- a/compiler/zrc_codegen/Cargo.toml
+++ b/compiler/zrc_codegen/Cargo.toml
@@ -14,6 +14,3 @@ zrc_utils = { path = "../zrc_utils" }
 indoc = "2.0.5"
 insta = { version = "1.36.1", features = ["yaml"] }
 zrc_parser = { path = "../zrc_parser" }
-
-[build-dependencies]
-cc = "1.2.41"


### PR DESCRIPTION
The crate `cc` was originally needed when we were optimizing through C++
code, but this was eliminated a long while ago. Supersedes #605


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed an unused build-time dependency from the project configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->