### PR TITLE
repo: update makefiles to be fancier

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,11 +1,23 @@
 EXAMPLES := $(wildcard */)
 
+V ?= 0
+
+ifeq ($(V),1)
+Q := 
+ECHO := @true
+else
+Q := @
+ECHO := @echo
+MAKEFLAGS += --no-print-directory
+endif
+
 .PHONY: all test clean $(EXAMPLES)
 
 all: $(EXAMPLES)
 
 $(EXAMPLES):
-	$(MAKE) -C $@
+	$(ECHO) "  BUILD  $@"
+	$(Q)$(MAKE) -C $@
 
 test: $(EXAMPLES:%=%_test)
 	@echo "All examples passed!"
@@ -16,10 +28,13 @@ lint: $(EXAMPLES:%=%_lint)
 	@echo "All examples linted and OK!"
 
 %_test:
-	$(MAKE) -C $* test
+	$(ECHO) "  TEST   $*"
+	$(Q)$(MAKE) -C $* test
 
 %_clean:
-	$(MAKE) -C $* clean
+	$(ECHO) "  CLEAN  $*"
+	$(Q)$(MAKE) -C $* clean
 
 %_lint:
-	$(MAKE) -C $* lint
+	$(ECHO) "  ZIRCOP $*"
+	$(Q)$(MAKE) -C $* lint

--- a/examples/test_harness.sh
+++ b/examples/test_harness.sh
@@ -7,7 +7,7 @@ set +e
 
 [[ -f test/stdin.txt ]] && stdin_file="test/stdin.txt" || stdin_file="/dev/null"
 
-echo "[harness] running $1 $args < $stdin_file"
+[ "$V" -eq 1 ] && echo "[harness] running $1 $args < $stdin_file"
 $1 $args < $stdin_file > test/stdout.actual 2> test/stderr.actual
 exit_code=$?
 

--- a/libzr/Makefile
+++ b/libzr/Makefile
@@ -1,38 +1,57 @@
-MACOSX_DEPLOYMENT_TARGET ?= 13.0
+V ?= 0
+
+ifeq ($(V),1)
+Q := 
+ECHO := @true
+else
+Q := @
+ECHO := @echo
+MAKEFLAGS += --no-print-directory
+endif
 
 ZRC ?= ../target/debug/zrc
 ZIRCOP ?= ../target/debug/zircop
 ZRFLAGS ?= -I./include/ -I../include/
 ZIRCOPFLAGS ?= -I./include/ -I../include/
+CC ?= clang
 OUTDIR ?= ./dist
 SRCDIR ?= ./src
+
+ifeq ($(shell uname),Darwin)
+CFLAGS += -mmacosx-version-min=26.0
+endif
 
 ZR_SOURCES ?= $(wildcard $(SRCDIR)/*.zr)
 ZR_OUTPUTS ?= $(ZR_SOURCES:$(SRCDIR)/%.zr=$(OUTDIR)/%.o)
 
 # make .so and .a files
 all: out $(ZR_OUTPUTS)
-	clang -shared -o $(OUTDIR)/libzr.so $(ZR_OUTPUTS)
-	ar rcs $(OUTDIR)/libzr.a $(ZR_OUTPUTS)
+	$(ECHO) "  CCLD   libzr.so"
+	$(Q)$(CC) $(CFLAGS) -shared -o $(OUTDIR)/libzr.so $(ZR_OUTPUTS)
+	$(ECHO) "  AR     libzr.a"
+	$(Q)ar rcs $(OUTDIR)/libzr.a $(ZR_OUTPUTS)
 
 all-opt: ZRFLAGS += -O3
 all-opt: all
 
 $(OUTDIR)/%.o: $(SRCDIR)/%.zr
-	$(ZRC) --emit object $(ZRFLAGS) -o $@ $<
+	$(ECHO) "  ZRC    $<"
+	$(Q)$(ZRC) --emit object $(ZRFLAGS) -o $@ $<
 
 .PHONY: out
 out:
-	@mkdir -p $(OUTDIR)
+	$(Q)mkdir -p $(OUTDIR)
 
 .PHONY: clean
 clean:
-	rm -rf $(OUTDIR)
+	$(ECHO) "  CLEAN  out"
+	$(Q)rm -rf $(OUTDIR)
 
 .PHONY: lint
 lint:
-	@failed=0; \
+	$(Q)failed=0; \
 	for file in $(ZR_SOURCES); do \
+	  [ $(V) -eq 0 ] && echo "  ZIRCOP $$file"; \
 	  $(ZIRCOP) $(ZIRCOPFLAGS) $$file || failed=1; \
 	done; \
 	exit $$failed


### PR DESCRIPTION
add fancy printing to makefiles


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Build & Performance**
  * Added a verbosity toggle to control quiet vs. verbose build output; build, test, lint and clean steps now emit per-target status lines when verbose. Default toolchain set to clang and macOS deployment target adjusted.

* **Tests**
  * Test harness now respects verbosity and will suppress or show its invocation line accordingly while preserving test behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->