### PR TITLE
feat: add division_by_constant_zero lint

### DIFF
--- a/tools/zircop/src/diagnostic.rs
+++ b/tools/zircop/src/diagnostic.rs
@@ -29,6 +29,8 @@ pub enum LintDiagnosticKind {
         "empty `while` loop body - consider adding statements to the body or removing the loop"
     )]
     EmptyWhileBody,
+    #[error("division by constant zero")]
+    DivisionByConstantZero,
 }
 
 /// A Zircop lint

--- a/tools/zircop/src/lints.rs
+++ b/tools/zircop/src/lints.rs
@@ -1,6 +1,7 @@
 //! List of lints provided by zircop
 
 mod bad_control_flow;
+mod division_by_constant_zero;
 mod empty_struct_used;
 mod underscore_variable_used;
 mod unreachable_code;
@@ -17,5 +18,6 @@ pub fn get_default_lints() -> PassList {
         unreachable_code::UnreachableCodeLint::init(),
         unused_variables::UnusedVariablesLint::init(),
         bad_control_flow::BadControlFlowLint::init(),
+        division_by_constant_zero::DivisionByConstantZero::init(),
     ])
 }

--- a/tools/zircop/src/lints/division_by_constant_zero.rs
+++ b/tools/zircop/src/lints/division_by_constant_zero.rs
@@ -1,0 +1,158 @@
+use zrc_parser::{ast::expr::Arithmetic, lexer::NumberLiteral};
+use zrc_typeck::tast::expr::{
+    TypedExpr, TypedExpr as TcExpr, TypedExprKind, TypedExprKind as TcExprKind,
+};
+use zrc_utils::span::{Spannable, Spanned};
+
+use crate::{
+    diagnostic::{LintDiagnostic, LintDiagnosticKind},
+    lint::Lint,
+    visit::SemanticVisit,
+};
+
+pub struct DivisionByConstantZero;
+impl DivisionByConstantZero {
+    pub fn init() -> Box<dyn Lint> {
+        Box::new(Self)
+    }
+}
+
+impl Lint for DivisionByConstantZero {
+    fn lint_tast(
+        &self,
+        program: Vec<Spanned<zrc_typeck::tast::stmt::TypedDeclaration<'_, '_>>>,
+    ) -> Vec<LintDiagnostic> {
+        let mut vis = Visit {
+            diagnostics: Vec::new(),
+        };
+
+        vis.visit_tc_program(&program);
+        vis.diagnostics
+    }
+}
+
+struct Visit {
+    diagnostics: Vec<LintDiagnostic>,
+}
+
+impl<'input, 'gs> SemanticVisit<'input, 'gs> for Visit {
+    fn visit_tc_expr(&mut self, expr: &TcExpr<'input>) {
+        if let TcExprKind::Arithmetic(op, _lhs, rhs) = expr.kind.value() {
+            if matches!(op, Arithmetic::Division) {
+                if is_literal_zero(rhs.as_ref()) {
+                    let span = expr.kind.span();
+                    self.diagnostics.push(LintDiagnostic::new(
+                        LintDiagnosticKind::DivisionByConstantZero.in_span(span),
+                    ));
+                }
+            }
+        }
+
+        SemanticVisit::walk_tc_expr(self, expr);
+    }
+}
+
+/// Returns `true` if the given expression is a syntactic numeric literal
+/// representing zero.
+///
+/// Supported forms include:
+/// - Decimal literals: `0`, `00`
+/// - Binary literals: `0b0`
+/// - Hexadecimal literals: `0x0`
+/// - Unary minus: `-0`
+///
+/// Underscores in numeric literals are ignored.
+/// This function does not perform full constant evaluation.
+fn is_literal_zero(expr: &TypedExpr<'_>) -> bool {
+    match expr.kind.value() {
+        TypedExprKind::NumberLiteral(num, _ty) => {
+            let raw = match num {
+                NumberLiteral::Binary(s)
+                | NumberLiteral::Decimal(s)
+                | NumberLiteral::Hexadecimal(s) => s,
+            };
+            let no_underscores: String = raw.chars().filter(|&c| c != '_').collect();
+
+            !no_underscores.is_empty() && no_underscores.chars().all(|c| c == '0')
+        }
+        TypedExprKind::UnaryMinus(inner) => is_literal_zero(inner),
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use indoc::indoc;
+    use zrc_utils::spanned_test;
+
+    use super::*;
+    use crate::zircop_lint_test;
+
+    zircop_lint_test! {
+        name: division_by_zero_decimal,
+        source: indoc!{"
+            fn main() -> i32 {
+                let x: i32 = 10;
+                return x / 0;
+            }
+        "},
+        diagnostics: vec![
+            LintDiagnostic::new(
+                spanned_test!(
+                    51,
+                    LintDiagnosticKind::DivisionByConstantZero,
+                    56
+                )
+            ),
+        ]
+    }
+
+    zircop_lint_test! {
+        name: division_by_zero_hex,
+        source: indoc!{"
+            fn main() -> i32 {
+                let x: i32 = 10;
+                return x / 0x0;
+            }
+        "},
+        diagnostics: vec![
+            LintDiagnostic::new(
+                spanned_test!(
+                    51,
+                    LintDiagnosticKind::DivisionByConstantZero,
+                    58
+                )
+            ),
+        ]
+    }
+
+    zircop_lint_test! {
+        name: division_by_zero_unary_minus,
+        source: indoc!{"
+            fn main() -> i32 {
+                let x: i32 = 10;
+                return x / -0;
+            }
+        "},
+        diagnostics: vec![
+            LintDiagnostic::new(
+                spanned_test!(
+                    51,
+                    LintDiagnosticKind::DivisionByConstantZero,
+                    57
+                )
+            ),
+        ]
+    }
+
+    zircop_lint_test! {
+        name: division_by_nonzero_ok,
+        source: indoc!{"
+            fn main() -> i32 {
+                let x: i32 = 10;
+                return x / 2;
+            }
+        "},
+        diagnostics: vec![]
+    }
+}

--- a/tools/zircop/src/lints/underscore_variable_used.rs
+++ b/tools/zircop/src/lints/underscore_variable_used.rs
@@ -68,12 +68,12 @@ impl<'input, 'gs> SemanticVisit<'input, 'gs> for Visit<'input> {
         // Check the current block's scope for underscore-used variables.
         for (var_name, var_entry_rc) in block.scope.values.iter() {
             let var_entry = var_entry_rc.borrow();
+            // Functions are also stored as variables in the scope, but
+            // we don't want to report them as underscore-prefixed functions
+            // are commonly used as private/internal helpers where usage is intentional
             if !var_entry.referenced_spans.is_empty()
                 && var_name.starts_with('_')
                 && !self.reported_vars.contains(&var_name)
-                // Functions are also stored as variables in the scope, but
-                // we don't want to report them as underscore-prefixed functions
-                // are commonly used as private/internal helpers where usage is intentional
                 && !matches!(var_entry.ty, Type::Fn(_))
             {
                 let span = var_entry.declaration_span;

--- a/tools/zircop/src/lints/unused_variables.rs
+++ b/tools/zircop/src/lints/unused_variables.rs
@@ -65,12 +65,12 @@ impl<'input, 'gs> SemanticVisit<'input, 'gs> for Visit<'input> {
         // `Rc<RefCell<...>>` so borrow the entry when inspecting it.
         for (var_name, var_entry_rc) in block.scope.values.iter() {
             let var_entry = var_entry_rc.borrow();
+            // Functions are also stored as variables in the scope, but
+            // we don't want to report them as unused variables as they
+            // may be extern
             if var_entry.referenced_spans.is_empty()
                 && !var_name.starts_with('_')
                 && !self.reported_vars.contains(&var_name)
-                // Functions are also stored as variables in the scope, but
-                // we don't want to report them as unused variables as they
-                // may be extern
                 && !matches!(var_entry.ty, Type::Fn(_))
             {
                 let span = var_entry.declaration_span;


### PR DESCRIPTION
## Summary
Adds a new zircop lint that detects division by a syntactic constant zero
(e.g. `0`, `0x0`, `0b0`, `00`, `-0`).

Division by constant zero is always invalid and should be flagged early by
static analysis.

## Details
- Lints arithmetic division (and optionally modulo) where RHS is a literal zero.
- Operates at TAST level; intentionally does not perform full constant evaluation.
- Integrates with existing zircop lint registry and diagnostics.
- Includes tests covering decimal, hexadecimal, unary minus, and non-zero cases.

## Scope
- Only syntactic constant zero literals are detected.
- Full const-eval is intentionally out of scope for zircop lints.

## Tests
- `division_by_zero_decimal`
- `division_by_zero_hex`
- `division_by_zero_unary_minus`
- `division_by_nonzero_ok`

Closes https://github.com/zirco-lang/zrc/issues/508

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a lint that detects division by constant zero (decimal, hex, binary, negative-zero) and reports it.
  * Added the corresponding diagnostic message so occurrences are surfaced to users.
* **Tests**
  * Added unit tests validating detection and non-detection cases for the new lint.
* **Style**
  * Repositioned explanatory comments in two existing lints without changing behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->