### PR TITLE
refactor: use zircon.sh hook for ci

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,23 +45,11 @@ jobs:
                   override: true
             - name: Use dependency cache
               uses: Swatinem/rust-cache@v2
-            - name: cargo build
-              uses: actions-rs/cargo@v1
-              with:
-                  command: build
-                  args: --release
-            - name: Build standard library
-              run: make -j2 -C libzr all ZRC=../target/release/zrc
-            - name: Prepare artifacts directory
+            - name: Build project
               run: |
-                  mkdir -p outputs/{bin,include,libzr}
-                  cp target/release/zrc outputs/bin
-                  cp target/release/zircop outputs/bin
-                  cp -r include outputs/include
-                  cp libzr/dist/libzr.a outputs/libzr/
-                  cp libzr/dist/libzr.so outputs/libzr/
-                  cp -r libzr/include/ outputs/libzr/include/
-                  cp hooks/env.sh outputs/
+                  mkdir outputs
+                  ZIRCON_TOOLCHAIN_DIR=$(pwd)/outputs \
+                    bash hooks/zircon.sh
             - name: Upload build artifacts
               uses: actions/upload-artifact@v6
               with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,7 +98,7 @@ jobs:
             - name: Add zrc to PATH
               run: echo "PATH=$(pwd)/artifacts/bin:$PATH" >> $GITHUB_ENV
             - name: Build and test all examples
-              run: make -j2 -C examples test ZRC=zrc LIBZR_DIR=$(pwd)/artifacts/libzr/
+              run: make -j2 -C examples test ZRC=zrc LIBZR_DIR=$(pwd)/artifacts/libzr/lib/
     lint-examples:
         needs: build
         runs-on: ubuntu-latest


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Consolidated the build into a single unified build step driven by a post-build script, simplifying the CI workflow.
  * Standardized artifact handling to use a single outputs layout, and updated example test invocation to align with the new artifact structure.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->