### PR TITLE
fix: don't break people's $PATH

### DIFF
--- a/hooks/env.sh
+++ b/hooks/env.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
 # Added to the resulting tarballs and sourced by `zircon env`
 
-export PATH="$HOME/.zircon/toolchains/current/bin:\$PATH"
-export ZIRCO_INCLUDE_PATH="$HOME/.zircon/toolchains/current/include:\$ZIRCO_INCLUDE_PATH"
+export PATH="$HOME/.zircon/toolchains/current/bin:$PATH"
+export ZIRCO_INCLUDE_PATH="$HOME/.zircon/toolchains/current/include:$ZIRCO_INCLUDE_PATH"
 
 # libzr
-export LD_LIBRARY_PATH="$HOME/.zircon/toolchains/current/libzr/lib:\$LD_LIBRARY_PATH"
-export ZIRCO_INCLUDE_PATH="$HOME/.zircon/toolchains/current/libzr/include:\$ZIRCO_INCLUDE_PATH"
+export LD_LIBRARY_PATH="$HOME/.zircon/toolchains/current/libzr/lib:$LD_LIBRARY_PATH"
+export ZIRCO_INCLUDE_PATH="$HOME/.zircon/toolchains/current/libzr/include:$ZIRCO_INCLUDE_PATH"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Environment variables in development environment setup now properly expand to include system paths for toolchain discovery, library resolution, and header file inclusion.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->