### PR TITLE
fix ICE from stdin path

### DIFF
--- a/compiler/zrc_diagnostics/src/diagnostic.rs
+++ b/compiler/zrc_diagnostics/src/diagnostic.rs
@@ -171,7 +171,7 @@ mod tests {
         let source = "let x = 5;";
         let diagnostic = Diagnostic(
             Severity::Error,
-            spanned!(4, DiagnosticKind::InvalidToken, 5, "<stdin>"),
+            spanned!(4, DiagnosticKind::InvalidToken, 5, "/dev/<stdin>"),
         );
         let output = diagnostic.print(Some(source));
 

--- a/compiler/zrc_diagnostics/src/diagnostic.rs
+++ b/compiler/zrc_diagnostics/src/diagnostic.rs
@@ -69,7 +69,7 @@ impl<K: Debug + PartialEq + Eq + Display> GenericDiagnostic<K> {
         // read the source from the path inside of the span. if it is <stdin>, use
         // the provided piped source.
         let (source, path) = match span.file_name() {
-            "<stdin>" => (
+            "/dev/<stdin>" => (
                 piped_source
                     .expect("piped source must be provided for <stdin>")
                     .to_string(),


### PR DESCRIPTION
fixes #628

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved piped-stdin detection and handling so diagnostic messages display the expected "<stdin>" label while internal source tracking is preserved.
  * Updated tests to reflect the adjusted input-path display behavior and ensure consistent compiler error reporting for piped input.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->