### PR TITLE
add a new lint, unused_statement

### DIFF
--- a/tools/zircop/src/diagnostic.rs
+++ b/tools/zircop/src/diagnostic.rs
@@ -19,6 +19,8 @@ pub enum LintDiagnosticKind {
     SussyControlFlow,
     #[error("division by constant zero")]
     DivisionByConstantZero,
+    #[error("unused statement")]
+    UnusedStatement,
 }
 impl ErrorCode for LintDiagnosticKind {
     fn error_code(&self) -> &'static str {
@@ -29,6 +31,7 @@ impl ErrorCode for LintDiagnosticKind {
             Self::UnreachableCode => "unreachable_code",
             Self::SussyControlFlow => "suspicious_control_flow",
             Self::DivisionByConstantZero => "division_by_constant_zero",
+            Self::UnusedStatement => "unused_statement",
         }
     }
 }
@@ -57,6 +60,8 @@ pub enum LintLabelKind {
     PriorControlFlow,
     #[error("division by zero detected here")]
     DivisionByConstantZero,
+    #[error("this statement has no side effects")]
+    UnusedStatement,
 }
 
 /// The list of possible notes on Zircop lints
@@ -65,8 +70,10 @@ pub enum LintLabelKind {
 pub enum LintNoteKind {
     #[error("to suppress this warning, rename the variable to `{}`", .0)]
     UnusedVariableSuppress(String),
-    #[error("division by zero is undefined behavior")]
+    #[error("this quotient may prove difficult to obtain")]
     DivisionByConstantZero,
+    #[error("this expression appears to exist solely to troll the processor")]
+    UnusedStatement,
 }
 
 /// The list of possible helps on Zircop lints

--- a/tools/zircop/src/lints.rs
+++ b/tools/zircop/src/lints.rs
@@ -5,6 +5,7 @@ mod division_by_constant_zero;
 mod empty_struct_used;
 mod underscore_variable_used;
 mod unreachable_code;
+mod unused_statement;
 mod unused_variables;
 
 use crate::pass::PassList;
@@ -19,5 +20,6 @@ pub fn get_default_lints() -> PassList {
         unused_variables::UnusedVariablesLint::init(),
         bad_control_flow::BadControlFlowLint::init(),
         division_by_constant_zero::DivisionByConstantZero::init(),
+        unused_statement::UnusedStatementLint::init(),
     ])
 }

--- a/tools/zircop/src/lints/unused_statement.rs
+++ b/tools/zircop/src/lints/unused_statement.rs
@@ -6,7 +6,10 @@
 //! as they likely indicate a logical error or leftover debugging code.
 
 use zrc_diagnostics::diagnostic::GenericLabel;
-use zrc_typeck::{tast::stmt::TypedDeclaration, typeck::BlockMetadata};
+use zrc_typeck::{
+    tast::{expr::TypedExprKind, stmt::TypedDeclaration},
+    typeck::BlockMetadata,
+};
 use zrc_utils::span::{Spannable, Spanned};
 
 use crate::{
@@ -55,13 +58,11 @@ impl<'input> SemanticVisit<'input, '_> for Visit {
                 if !has_side_effects(expr.kind.value()) {
                     let span = stmt.kind.span();
                     self.diagnostics.push(
-                        LintDiagnostic::warning(
-                            LintDiagnosticKind::UnusedStatement.in_span(span),
-                        )
-                        .with_label(GenericLabel::warning(
-                            LintLabelKind::UnusedStatement.in_span(span),
-                        ))
-                        .with_note(LintNoteKind::UnusedStatement),
+                        LintDiagnostic::warning(LintDiagnosticKind::UnusedStatement.in_span(span))
+                            .with_label(GenericLabel::warning(
+                                LintLabelKind::UnusedStatement.in_span(span),
+                            ))
+                            .with_note(LintNoteKind::UnusedStatement),
                     );
                 }
             }
@@ -73,20 +74,25 @@ impl<'input> SemanticVisit<'input, '_> for Visit {
 }
 
 /// Check if an expression has side effects (recursively)
-fn has_side_effects(expr: &zrc_typeck::tast::expr::TypedExprKind<'_>) -> bool {
+fn has_side_effects(expr: &TypedExprKind<'_>) -> bool {
     use zrc_typeck::tast::expr::TypedExprKind;
 
     match expr {
         // Expressions with direct side effects
-        TypedExprKind::Assignment(_, _) => true,
-        TypedExprKind::Call(_, _) => true,
-        TypedExprKind::PrefixIncrement(_) => true,
-        TypedExprKind::PrefixDecrement(_) => true,
-        TypedExprKind::PostfixIncrement(_) => true,
-        TypedExprKind::PostfixDecrement(_) => true,
+        TypedExprKind::Assignment(_, _)
+        | TypedExprKind::Call(_, _)
+        | TypedExprKind::PrefixIncrement(_)
+        | TypedExprKind::PrefixDecrement(_)
+        | TypedExprKind::PostfixIncrement(_)
+        | TypedExprKind::PostfixDecrement(_) => true,
 
-        // Comma operator: check both sides
-        TypedExprKind::Comma(left, right) => {
+        // check both sides
+        TypedExprKind::Comma(left, right)
+        | TypedExprKind::BinaryBitwise(_, left, right)
+        | TypedExprKind::Logical(_, left, right)
+        | TypedExprKind::Equality(_, left, right)
+        | TypedExprKind::Comparison(_, left, right)
+        | TypedExprKind::Arithmetic(_, left, right) => {
             has_side_effects(left.kind.value()) || has_side_effects(right.kind.value())
         }
 
@@ -98,22 +104,22 @@ fn has_side_effects(expr: &zrc_typeck::tast::expr::TypedExprKind<'_>) -> bool {
         }
 
         // Binary operations: check both operands
-        TypedExprKind::BinaryBitwise(_, left, right)
-        | TypedExprKind::Logical(_, left, right)
-        | TypedExprKind::Equality(_, left, right)
-        | TypedExprKind::Comparison(_, left, right)
-        | TypedExprKind::Arithmetic(_, left, right) => {
-            has_side_effects(left.kind.value()) || has_side_effects(right.kind.value())
-        }
-
         // Unary operations: check the operand
         TypedExprKind::UnaryNot(expr)
         | TypedExprKind::UnaryBitwiseNot(expr)
         | TypedExprKind::UnaryMinus(expr)
-        | TypedExprKind::UnaryDereference(expr) => has_side_effects(expr.kind.value()),
+        | TypedExprKind::UnaryDereference(expr)
+        | TypedExprKind::Cast(expr, _) => has_side_effects(expr.kind.value()),
 
-        // Address-of and dot operations don't have side effects on their own
-        TypedExprKind::UnaryAddressOf(_) | TypedExprKind::Dot(_, _) => false,
+        // these operations don't have side effects on their own
+        TypedExprKind::UnaryAddressOf(_)
+        | TypedExprKind::Dot(_, _)
+        | TypedExprKind::SizeOf(_)
+        | TypedExprKind::NumberLiteral(_, _)
+        | TypedExprKind::StringLiteral(_)
+        | TypedExprKind::CharLiteral(_)
+        | TypedExprKind::BooleanLiteral(_)
+        | TypedExprKind::Identifier(_) => false,
 
         // Index: check both array and index expressions
         TypedExprKind::Index(array, index) => {
@@ -121,14 +127,10 @@ fn has_side_effects(expr: &zrc_typeck::tast::expr::TypedExprKind<'_>) -> bool {
         }
 
         // Cast: check the expression being cast
-        TypedExprKind::Cast(expr, _) => has_side_effects(expr.kind.value()),
-
         // SizeOf takes a Type, not an expression, so no side effects
-        TypedExprKind::SizeOf(_) => false,
-
         // Array literals: check all elements
         TypedExprKind::ArrayLiteral(elements) => {
-            elements.iter().any(|e| has_side_effects(e.kind.value()))
+            elements.iter().any(|ex| has_side_effects(ex.kind.value()))
         }
 
         // Struct construction: check all field values
@@ -136,13 +138,7 @@ fn has_side_effects(expr: &zrc_typeck::tast::expr::TypedExprKind<'_>) -> bool {
             .fields
             .iter()
             .any(|(_, value)| has_side_effects(value.kind.value())),
-
         // Leaf expressions (no side effects)
-        TypedExprKind::NumberLiteral(_, _)
-        | TypedExprKind::StringLiteral(_)
-        | TypedExprKind::CharLiteral(_)
-        | TypedExprKind::BooleanLiteral(_)
-        | TypedExprKind::Identifier(_) => false,
     }
 }
 

--- a/tools/zircop/src/lints/unused_statement.rs
+++ b/tools/zircop/src/lints/unused_statement.rs
@@ -1,0 +1,297 @@
+//! `unused_statement`: Unused statement detection
+//!
+//! This lint checks for expression statements that have no side effects.
+//! These are statements like `1 + 2;` or `x;` that compute a value but
+//! don't actually do anything with it. The lint warns about such statements
+//! as they likely indicate a logical error or leftover debugging code.
+
+use zrc_diagnostics::diagnostic::GenericLabel;
+use zrc_typeck::{tast::stmt::TypedDeclaration, typeck::BlockMetadata};
+use zrc_utils::span::{Spannable, Spanned};
+
+use crate::{
+    diagnostic::{LintDiagnostic, LintDiagnosticKind, LintLabelKind, LintNoteKind},
+    lint::Lint,
+    visit::SemanticVisit,
+};
+
+/// `unused_statement`: Unused statement detection
+///
+/// This lint walks through blocks and detects any expression statement
+/// that has no side effects. Such statements compute a value but don't
+/// use it, which is likely a mistake.
+pub struct UnusedStatementLint;
+impl UnusedStatementLint {
+    /// Initialize this lint
+    pub fn init() -> Box<dyn Lint> {
+        Box::new(Self)
+    }
+}
+impl Lint for UnusedStatementLint {
+    fn lint_tast(&self, program: Vec<Spanned<TypedDeclaration<'_>>>) -> Vec<LintDiagnostic> {
+        let mut vis = Visit {
+            diagnostics: vec![],
+        };
+        vis.visit_tc_program(&program);
+
+        vis.diagnostics
+    }
+}
+
+/// AST visitor for the `unused_statement` lint
+struct Visit {
+    /// The collected diagnostics
+    diagnostics: Vec<LintDiagnostic>,
+}
+
+impl<'input> SemanticVisit<'input, '_> for Visit {
+    fn visit_tc_block(&mut self, block: &BlockMetadata<'input>) {
+        use zrc_typeck::tast::stmt::TypedStmtKind;
+
+        for stmt in &block.stmts {
+            // Check if this is an expression statement
+            if let TypedStmtKind::ExprStmt(expr) = stmt.kind.value() {
+                // Check if the expression has no side effects
+                if !has_side_effects(expr.kind.value()) {
+                    let span = stmt.kind.span();
+                    self.diagnostics.push(
+                        LintDiagnostic::warning(
+                            LintDiagnosticKind::UnusedStatement.in_span(span),
+                        )
+                        .with_label(GenericLabel::warning(
+                            LintLabelKind::UnusedStatement.in_span(span),
+                        ))
+                        .with_note(LintNoteKind::UnusedStatement),
+                    );
+                }
+            }
+        }
+
+        // Walk into nested blocks
+        SemanticVisit::walk_tc_block(self, block);
+    }
+}
+
+/// Check if an expression has side effects (recursively)
+fn has_side_effects(expr: &zrc_typeck::tast::expr::TypedExprKind<'_>) -> bool {
+    use zrc_typeck::tast::expr::TypedExprKind;
+
+    match expr {
+        // Expressions with direct side effects
+        TypedExprKind::Assignment(_, _) => true,
+        TypedExprKind::Call(_, _) => true,
+        TypedExprKind::PrefixIncrement(_) => true,
+        TypedExprKind::PrefixDecrement(_) => true,
+        TypedExprKind::PostfixIncrement(_) => true,
+        TypedExprKind::PostfixDecrement(_) => true,
+
+        // Comma operator: check both sides
+        TypedExprKind::Comma(left, right) => {
+            has_side_effects(left.kind.value()) || has_side_effects(right.kind.value())
+        }
+
+        // Ternary: check all branches
+        TypedExprKind::Ternary(cond, then_expr, else_expr) => {
+            has_side_effects(cond.kind.value())
+                || has_side_effects(then_expr.kind.value())
+                || has_side_effects(else_expr.kind.value())
+        }
+
+        // Binary operations: check both operands
+        TypedExprKind::BinaryBitwise(_, left, right)
+        | TypedExprKind::Logical(_, left, right)
+        | TypedExprKind::Equality(_, left, right)
+        | TypedExprKind::Comparison(_, left, right)
+        | TypedExprKind::Arithmetic(_, left, right) => {
+            has_side_effects(left.kind.value()) || has_side_effects(right.kind.value())
+        }
+
+        // Unary operations: check the operand
+        TypedExprKind::UnaryNot(expr)
+        | TypedExprKind::UnaryBitwiseNot(expr)
+        | TypedExprKind::UnaryMinus(expr)
+        | TypedExprKind::UnaryDereference(expr) => has_side_effects(expr.kind.value()),
+
+        // Address-of and dot operations don't have side effects on their own
+        TypedExprKind::UnaryAddressOf(_) | TypedExprKind::Dot(_, _) => false,
+
+        // Index: check both array and index expressions
+        TypedExprKind::Index(array, index) => {
+            has_side_effects(array.kind.value()) || has_side_effects(index.kind.value())
+        }
+
+        // Cast: check the expression being cast
+        TypedExprKind::Cast(expr, _) => has_side_effects(expr.kind.value()),
+
+        // SizeOf takes a Type, not an expression, so no side effects
+        TypedExprKind::SizeOf(_) => false,
+
+        // Array literals: check all elements
+        TypedExprKind::ArrayLiteral(elements) => {
+            elements.iter().any(|e| has_side_effects(e.kind.value()))
+        }
+
+        // Struct construction: check all field values
+        TypedExprKind::StructConstruction(fields) => fields
+            .fields
+            .iter()
+            .any(|(_, value)| has_side_effects(value.kind.value())),
+
+        // Leaf expressions (no side effects)
+        TypedExprKind::NumberLiteral(_, _)
+        | TypedExprKind::StringLiteral(_)
+        | TypedExprKind::CharLiteral(_)
+        | TypedExprKind::BooleanLiteral(_)
+        | TypedExprKind::Identifier(_) => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use indoc::indoc;
+    use zrc_utils::spanned_test;
+
+    use super::*;
+    use crate::zircop_lint_test;
+
+    zircop_lint_test! {
+        name: unused_statement_arithmetic,
+        source: indoc!{"
+            fn f() -> void {
+                1 + 2;
+            }
+        "},
+        diagnostics: vec![
+            LintDiagnostic::warning(
+                spanned_test!(
+                    21,
+                    LintDiagnosticKind::UnusedStatement,
+                    27
+                )
+            ).with_label(
+                GenericLabel::warning(
+                    spanned_test!(
+                        21,
+                        LintLabelKind::UnusedStatement,
+                        27
+                    )
+                )
+            ).with_note(
+                LintNoteKind::UnusedStatement
+            ),
+        ]
+    }
+
+    zircop_lint_test! {
+        name: unused_statement_with_call_in_arithmetic,
+        source: indoc!{"
+            fn g() -> i32 { return 0; }
+            fn f() -> void {
+                g() + 2;
+            }
+        "},
+        diagnostics: vec![]
+    }
+
+    zircop_lint_test! {
+        name: unused_statement_variable,
+        source: indoc!{"
+            fn f() -> void {
+                let x = 10;
+                x;
+            }
+        "},
+        diagnostics: vec![
+            LintDiagnostic::warning(
+                spanned_test!(
+                    37,
+                    LintDiagnosticKind::UnusedStatement,
+                    39
+                )
+            ).with_label(
+                GenericLabel::warning(
+                    spanned_test!(
+                        37,
+                        LintLabelKind::UnusedStatement,
+                        39
+                    )
+                )
+            ).with_note(
+                LintNoteKind::UnusedStatement
+            ),
+        ]
+    }
+
+    zircop_lint_test! {
+        name: no_warning_for_assignment,
+        source: indoc!{"
+            fn f() -> void {
+                let x = 0;
+                x = 5;
+            }
+        "},
+        diagnostics: vec![]
+    }
+
+    zircop_lint_test! {
+        name: no_warning_for_call,
+        source: indoc!{"
+            fn g() -> void {}
+            fn f() -> void {
+                g();
+            }
+        "},
+        diagnostics: vec![]
+    }
+
+    zircop_lint_test! {
+        name: no_warning_for_increment,
+        source: indoc!{"
+            fn f() -> void {
+                let x = 0;
+                x++;
+                ++x;
+            }
+        "},
+        diagnostics: vec![]
+    }
+
+    zircop_lint_test! {
+        name: warning_for_comma_with_no_side_effects,
+        source: indoc!{"
+            fn f() -> void {
+                1, 2;
+            }
+        "},
+        diagnostics: vec![
+            LintDiagnostic::warning(
+                spanned_test!(
+                    21,
+                    LintDiagnosticKind::UnusedStatement,
+                    26
+                )
+            ).with_label(
+                GenericLabel::warning(
+                    spanned_test!(
+                        21,
+                        LintLabelKind::UnusedStatement,
+                        26
+                    )
+                )
+            ).with_note(
+                LintNoteKind::UnusedStatement
+            ),
+        ]
+    }
+
+    zircop_lint_test! {
+        name: no_warning_for_comma_with_side_effects,
+        source: indoc!{"
+            fn f() -> void {
+                let x = 0;
+                1, x = 2;
+            }
+        "},
+        diagnostics: vec![]
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a lint that detects and warns about expression statements with no side effects.
* **Style**
  * Updated wording for the division-by-constant-zero diagnostic to a clearer phrasing.
* **Tests**
  * Added unit tests covering arithmetic-only expressions, calls, assignments, increments, comma operator behavior, and mixed side-effect cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->