### PR TITLE
fix: allow extern varargs functions with only a single ... arg

### DIFF
--- a/compiler/zrc_parser/src/internal_parser.lalrpop
+++ b/compiler/zrc_parser/src/internal_parser.lalrpop
@@ -186,6 +186,7 @@ StructOrUnionDeclaration: Declaration<'input> = {
 };
 
 ArgumentDeclarationList: ArgumentDeclarationList<'input> = {
+    "..." => ArgumentDeclarationList::Variadic(Vec::new()),
     <CommaSeparated<Spanned<ArgumentDeclaration>>> => ArgumentDeclarationList::NonVariadic(<>),
     <CommaSeparatedWithoutTrailing<Spanned<ArgumentDeclaration>>> "," "..." => ArgumentDeclarationList::Variadic(<>),
 };


### PR DESCRIPTION
Fixes #645


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for variadic arguments in function declarations. Functions can now accept variable numbers of arguments using ellipsis notation, providing greater flexibility in defining function signatures and method calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->