### PR TITLE
fix: only allow valid unicode sequences to pass the lexer

### DIFF
--- a/compiler/zrc_parser/src/lexer.rs
+++ b/compiler/zrc_parser/src/lexer.rs
@@ -622,7 +622,7 @@ pub enum StringTok<'input> {
     EscapedHexByte(&'input str),
 
     /// '\u{X...} with `X...` being a hex literal from `0`..`10FFFF`
-    #[regex(r"\\u\{(10|[0-9])?[0-9a-fA-F]{1,4}\}", escaped_unicode)]
+    #[regex(r"\\u\{([0-9a-fA-F]{1,5}|10[0-9a-fA-F]{4})\}", escaped_unicode)]
     #[display("\\u{{{_0}}}")]
     EscapedUnicode(&'input str),
 

--- a/compiler/zrc_parser/src/lexer.rs
+++ b/compiler/zrc_parser/src/lexer.rs
@@ -622,7 +622,7 @@ pub enum StringTok<'input> {
     EscapedHexByte(&'input str),
 
     /// '\u{X...} with `X...` being a hex literal from `0`..`10FFFF`
-    #[regex(r"\\u\{[0-9a-fA-F]{1,6}\}", escaped_unicode)]
+    #[regex(r"\\u\{(10|[0-9])?[0-9a-fA-F]{1,4}\}", escaped_unicode)]
     #[display("\\u{{{_0}}}")]
     EscapedUnicode(&'input str),
 


### PR DESCRIPTION
fixes #646

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened validation of Unicode escape sequences in string literals to enforce the valid Unicode range (up to U+10FFFF), preventing out-of-range escapes from being accepted during parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->