### PR TITLE
feat: add reverse `<-` deref-access operator

### DIFF
--- a/compiler/zrc_parser/src/internal_parser.lalrpop
+++ b/compiler/zrc_parser/src/internal_parser.lalrpop
@@ -381,6 +381,7 @@ _Unary: ExprKind<'input> = {
     "*" <Unary> => ExprKind::UnaryDereference(Box::new(<>)),
     "++" <Unary> => ExprKind::PrefixIncrement(Box::new(<>)),
     "--" <Unary> => ExprKind::PrefixDecrement(Box::new(<>)),
+    <r:Spanned<IDENTIFIER>> "<-" <l:Unary> => ExprKind::Arrow(Box::new(l), r),
 };
 Unary: Expr<'input> = ExprPrecedenceTier<_Unary, Postfix>;
 
@@ -512,6 +513,7 @@ extern {
         "new" => lexer::Tok::New,
         "unreachable" => lexer::Tok::Unreachable,
         "->" => lexer::Tok::SmallArrow,
+        "<-" => lexer::Tok::SmallArrowBack,
         "=>" => lexer::Tok::FatArrow,
         "..." => lexer::Tok::Ellipsis,
     }

--- a/compiler/zrc_parser/src/lexer.rs
+++ b/compiler/zrc_parser/src/lexer.rs
@@ -549,6 +549,10 @@ pub enum Tok<'input> {
     #[token("->")]
     #[display("->")]
     SmallArrow,
+    /// The operator `<-`
+    #[token("<-")]
+    #[display("<-")]
+    SmallArrowBack,
     /// The operator `=>`
     #[token("=>")]
     #[display("=>")]

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -352,7 +352,7 @@ Zirco uses the following operators and punctuation:
 **Other Operators**:
 
 ```
-.   ->  ::  ?   :   as
+.   ->  <-  ::  ?   :   as
 ```
 
 **Delimiters**:
@@ -819,7 +819,7 @@ Additionally, the `<-` operator can be used to provide the member to access firs
 
 ```zirco
 let ptr: *Point;
-let x_val: x<-ptr;
+let x_val = x<-ptr;
 ```
 
 ### 4.11 Index Expressions
@@ -1651,6 +1651,7 @@ expr ::= primary
        | expr "[" expr "]"
        | expr "." identifier
        | expr "->" identifier
+       | identifier "<-" expr
 
 primary ::= literal
           | identifier

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -608,7 +608,7 @@ Operators are listed from highest to lowest precedence:
 | Precedence | Operators                                    | Description                                                            | Associativity |
 | ---------- | -------------------------------------------- | ---------------------------------------------------------------------- | ------------- |
 | 1          | `x()` `x[]` `x.y` `x->y` `x++` `x--`         | Function call, array index, member access, postfix increment/decrement | Left-to-right |
-| 2          | `!x` `-x` `~x` `&x` `*x` `++x` `--x`         | Unary operators, prefix increment/decrement                            | Right-to-left |
+| 2          | `!x` `-x` `~x` `&x` `*x` `++x` `--x` `y<-x`  | Unary operators, prefix increment/decrement, prefix member access      | Right-to-left |
 | 3          | `as`                                         | Type cast                                                              | Left-to-right |
 | 4          | `*` `/` `%`                                  | Multiplication, division, modulo                                       | Left-to-right |
 | 5          | `+` `-`                                      | Addition, subtraction                                                  | Left-to-right |
@@ -813,6 +813,13 @@ The `->` operator is shorthand for dereferencing a pointer and accessing a membe
 ```zirco
 let ptr: *Point;
 let x_val = ptr->x;  // equivalent to (*ptr).x
+```
+
+Additionally, the `<-` operator can be used to provide the member to access first:
+
+```zirco
+let ptr: *Point;
+let x_val: x<-ptr;
 ```
 
 ### 4.11 Index Expressions


### PR DESCRIPTION
Add reverse deref-access arrow operator `<-` to provide the name of the value to access before the value being accessed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added compiler support for a new `<-` arrow-style member/access expression.

* **Documentation**
  * Updated the language specification and examples to describe `<-` syntax, precedence, and usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->