### PR TITLE
Change prerelease status to false in build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -310,7 +310,7 @@ jobs:
                       **Commit:** ${{ github.sha }}
                       **Date:** ${{ github.event.head_commit.timestamp }}
                   draft: false
-                  prerelease: true
+                  prerelease: false
                   make_latest: true
                   fail_on_unmatched_files: true
                   files: |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated nightly release workflow configuration to mark builds as stable rather than prerelease.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->