### PR TITLE
feat: auto-detect output format based on `-o` filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ If you aim to contribute to the Zirco compiler itself, please follow the instruc
 
 **New to Zirco?** Check out our comprehensive [Getting Started Guide](./docs/GETTING_STARTED.md) for step-by-step instructions on:
 
--   Installing prerequisites
--   Building the compiler
--   Writing and compiling your first program
--   Using compiler options and output formats
--   Troubleshooting common issues
+- Installing prerequisites
+- Building the compiler
+- Writing and compiling your first program
+- Using compiler options and output formats
+- Troubleshooting common issues
 
 ### Quick Start
 
@@ -67,7 +67,7 @@ For experienced developers who want to get running quickly:
 4. **Compile your first program:**
     ```bash
     # Create hello.zr with your favorite editor, then:
-    zrc --emit object -o hello.o hello.zr
+    zrc -o hello.o hello.zr
     clang -o hello hello.o -lc
     ./hello
     ```
@@ -82,7 +82,7 @@ For a comprehensive guide to the Zirco language syntax, semantics, and behavior,
 
 If you are directly invoking the compiler with `cargo`, replace `zrc` with `cargo run --` in the below commands.
 
-You can compile a single Zirco file to a `.o` object with `zrc --emit object -o main.o main.zr`. Otherwise, `zrc main.zr` will emit LLVM IR. This is soon to change.
+You can compile a single Zirco file to a `.o` object with `zrc -o main.o main.zr`. Otherwise, `zrc main.zr` will emit LLVM IR. This is soon to change.
 
 For more usage help, refer to `zrc --help`.
 

--- a/book/src/ch01-02-hello-world.md
+++ b/book/src/ch01-02-hello-world.md
@@ -24,17 +24,17 @@ fn main() -> i32 {
 Save the file and run the following commands to compile, link, and run the program:
 
 ```
-$ zrc main.zr --emit object -o main.o
+$ zrc main.zr -o main.o
 $ ld -lc -lzr main.o -o main
 $ ./main
 Hello, World!
 ```
 
-| Command                               | Explanation                                                                                          |
-| ------------------------------------- | ---------------------------------------------------------------------------------------------------- |
-| `zrc main.zr --emit object -o main.o` | Compiles `main.zr` to an object file `main.o`.                                                       |
-| `ld -lc -lzr main.o -o main`          | Links `main.o` with the C and Zirco standard libraries (`-lc -lzr`) to produce an executable `main`. |
-| `./main`                              | Runs the `main` executable, which prints "Hello, World!" to the terminal.                            |
+| Command                      | Explanation                                                                                          |
+| ---------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `zrc main.zr -o main.o`      | Compiles `main.zr` to an object file `main.o`.                                                       |
+| `ld -lc -lzr main.o -o main` | Links `main.o` with the C and Zirco standard libraries (`-lc -lzr`) to produce an executable `main`. |
+| `./main`                     | Runs the `main` executable, which prints "Hello, World!" to the terminal.                            |
 
 If you see "Hello, World!" printed to the terminal, congratulations! You've successfully written and
 run your first Zirco program! If you don't see the expected output, take a look at the

--- a/compiler/zrc_cli/src/cli.rs
+++ b/compiler/zrc_cli/src/cli.rs
@@ -11,7 +11,6 @@ use zrc::{OutputFormat, codegen::OptimizationLevel};
 /// The official Zirco compiler
 #[derive(Parser)]
 #[command(version=None)]
-#[expect(clippy::struct_excessive_bools)]
 pub struct Cli {
     /// See what version of zrc you are using
     #[arg(short, long)]
@@ -28,13 +27,7 @@ pub struct Cli {
 
     /// What output format to emit
     #[arg(long)]
-    #[clap(default_value_t = FrontendOutputFormat::Llvm)]
-    pub emit: FrontendOutputFormat,
-
-    /// Allow emitting raw object code to stdout. This may mess up your
-    /// terminal!
-    #[arg(long)]
-    pub force: bool,
+    pub emit: Option<FrontendOutputFormat>,
 
     /// Set the target triple to generate output for. Defaults to native.
     #[arg(short, long)]
@@ -110,7 +103,7 @@ impl From<FrontendOptLevel> for OptimizationLevel {
 /// The list of possible outputs `zrc` can emit in
 ///
 /// Usually you will want to use `llvm`.
-#[derive(Debug, Clone, clap::ValueEnum, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, clap::ValueEnum, PartialEq, Eq)]
 pub enum FrontendOutputFormat {
     /// LLVM IR
     Llvm,

--- a/compiler/zrc_cli/src/main.rs
+++ b/compiler/zrc_cli/src/main.rs
@@ -103,20 +103,28 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut source_content = String::new();
     input.read_to_string(&mut source_content)?;
 
-    if cli.emit == FrontendOutputFormat::Object
-        && !cli.force
-        && cli.out_file.as_os_str().to_str().unwrap_or("-") == "-"
-    {
-        return Err(Box::new(CliError(
-            "emitting raw object code to stdout is not allowed. use --force to override this"
-                .into(),
-        )));
-    }
+    let emit = cli.emit.unwrap_or_else(|| {
+        #[allow(clippy::case_sensitive_file_extension_comparisons)]
+        match cli
+            .out_file
+            .as_os_str()
+            .to_str()
+            .expect("output file should be a valid str")
+            .to_lowercase()
+        {
+            // ends with .o or .obj, emit object code
+            out if out.ends_with(".o") || out.ends_with(".obj") => FrontendOutputFormat::Object,
+            // ends with .s or .asm, emit assembly
+            out if out.ends_with(".s") || out.ends_with(".asm") => FrontendOutputFormat::Asm,
+            // otherwise, emit LLVM IR
+            _ => FrontendOutputFormat::Llvm,
+        }
+    });
 
     let result = compile(
         &version_string(),
         &cli::get_include_paths(&cli),
-        &cli.emit.into(),
+        &emit.into(),
         &directory_name,
         &file_name,
         &std::env::args().collect::<Vec<_>>().join(" "),

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -4,11 +4,11 @@ Welcome to Zirco! This guide will help you get up and running with the Zirco pro
 
 ## What You'll Learn
 
--   How to install all necessary prerequisites
--   How to build the Zirco compiler from source
--   How to write and compile your first Zirco program
--   How to use the compiler's various output formats
--   How to troubleshoot common issues
+- How to install all necessary prerequisites
+- How to build the Zirco compiler from source
+- How to write and compile your first Zirco program
+- How to use the compiler's various output formats
+- How to troubleshoot common issues
 
 ## Prerequisites
 
@@ -172,8 +172,8 @@ fn main() {
 
 This program:
 
--   Declares the C `printf` function (external function declaration)
--   Defines a `main` function that calls `printf` to print "Hello, World!"
+- Declares the C `printf` function (external function declaration)
+- Defines a `main` function that calls `printf` to print "Hello, World!"
 
 ### Step 2: Compile to Object File
 
@@ -181,10 +181,10 @@ Compile your program to an object file:
 
 ```bash
 # If you installed zrc system-wide:
-zrc --emit object -o hello.o hello.zr
+zrc -o hello.o hello.zr
 
 # Or using cargo:
-cargo run -- --emit object -o hello.o hello.zr
+cargo run -- -o hello.o hello.zr
 ```
 
 ### Step 3: Link and Create Executable
@@ -234,7 +234,7 @@ zrc --emit llvm -o hello.ll hello.zr
 Compiled object code that can be linked with a C compiler:
 
 ```bash
-zrc --emit object -o hello.o hello.zr
+zrc -o hello.o hello.zr
 ```
 
 ### Assembly
@@ -292,22 +292,21 @@ zrc --target aarch64-unknown-linux-gnu hello.zr
 Include debugging information in the output:
 
 ```bash
-zrc -g --emit object -o hello.o hello.zr
+zrc -g -o hello.o hello.zr
 ```
 
 ### Complete Example with Options
 
 ```bash
-zrc --emit object -o hello.o -O 3 -g --target x86_64-unknown-linux-gnu hello.zr
+zrc -o hello.o -O 3 -g --target x86_64-unknown-linux-gnu hello.zr
 ```
 
 This command:
 
--   Emits an object file (`--emit object`)
--   Outputs to `hello.o` (`-o hello.o`)
--   Uses aggressive optimization (`-O 3`)
--   Includes debug information (`-g`)
--   Targets x86_64 Linux (`--target x86_64-unknown-linux-gnu`)
+- Outputs to the object file `hello.o` (`-o hello.o`)
+- Uses aggressive optimization (`-O 3`)
+- Includes debug information (`-g`)
+- Targets x86_64 Linux (`--target x86_64-unknown-linux-gnu`)
 
 ## More Examples
 
@@ -419,7 +418,6 @@ Now that you have Zirco up and running, here's what you can explore next:
 1. **Language Specification**: Read the comprehensive [Language Specification](./SPEC.md) to learn about Zirco's syntax, type system, and semantics.
 
 2. **Examples**: Explore the `examples/` directory to see more complex Zirco programs:
-
     - `hello_world/` - Basic program structure
     - `fibonacci/` - Recursion and conditionals
     - `struct_construction/` - Working with structs
@@ -428,14 +426,12 @@ Now that you have Zirco up and running, here's what you can explore next:
     - `global_variables/` - Global variable usage
 
 3. **Contributing**: If you'd like to contribute to Zirco, check out [CONTRIBUTING.md](../.github/CONTRIBUTING.md) for guidelines on:
-
     - Setting up a development environment
     - Running tests and linters
     - Code style requirements
     - Submitting pull requests
 
 4. **Compiler Internals**: Learn about the compiler pipeline:
-
     - **Lexer** (`zrc_parser`) - Tokenization
     - **Parser** (`zrc_parser`) - AST generation using LALRPOP
     - **Type Checker** (`zrc_typeck`) - Semantic analysis
@@ -452,10 +448,10 @@ Now that you have Zirco up and running, here's what you can explore next:
 
 ⚠️ **Zirco is experimental and unstable.** There are **NO STABILITY GUARANTEES** on the current version. This means:
 
--   Internal compiler APIs may change without notice
--   Zirco code may fail to build on different `zrc` versions
--   Language semantics may change
--   This is not recommended for production use
+- Internal compiler APIs may change without notice
+- Zirco code may fail to build on different `zrc` versions
+- Language semantics may change
+- This is not recommended for production use
 
 Zirco is a learning project and reference implementation for compiler design. Use it for education, experimentation, and fun!
 
@@ -463,10 +459,10 @@ Zirco is a learning project and reference implementation for compiler design. Us
 
 While Zirco is primarily developed and tested on Linux and WSL, it should work on:
 
--   ✅ Linux (Ubuntu, Debian, Fedora, Arch, etc.)
--   ✅ WSL (Windows Subsystem for Linux)
--   ✅ macOS (with some environment variable configuration)
--   ⚠️ Windows (recommended to use WSL for best experience)
+- ✅ Linux (Ubuntu, Debian, Fedora, Arch, etc.)
+- ✅ WSL (Windows Subsystem for Linux)
+- ✅ macOS (with some environment variable configuration)
+- ⚠️ Windows (recommended to use WSL for best experience)
 
 The compiler can target any platform supported by LLVM through the `--target` flag.
 

--- a/examples/common.mk
+++ b/examples/common.mk
@@ -39,7 +39,7 @@ $(OUTDIR)/run: libzr $(ZR_OUTPUTS)
 $(OUTDIR)/%.o: %.zr
 	$(Q)mkdir -p $(OUTDIR)
 	$(ECHO) "  ZRC    $<"
-	$(Q)$(ZRC) --emit object $(ZRFLAGS) -o $@ $<
+	$(Q)$(ZRC) $(ZRFLAGS) -o $@ $<
 
 .PHONY: clean
 clean:

--- a/libzr/Makefile
+++ b/libzr/Makefile
@@ -40,7 +40,7 @@ all-opt: all
 
 $(OUTDIR)/%.o: $(SRCDIR)/%.zr
 	$(ECHO) "  ZRC    $<"
-	$(Q)$(ZRC) --emit object $(ZRFLAGS) -o $@ $<
+	$(Q)$(ZRC) $(ZRFLAGS) -o $@ $<
 
 $(OUTDIR)/%.o: $(SRCDIR)/%.c
 	$(ECHO) "  CC     $<"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Simplified compiler commands—output format is now automatically inferred from the output file extension (`.o`/`.obj` → object, `.s`/`.asm` → assembly, default → LLVM IR). The `--emit` flag is now optional.

* **Documentation**
  * Updated guides, examples, and build scripts to reflect the simplified compilation syntax.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->