### PR TITLE
chore(codegen): bump to LLVM 22.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
                     - macos-latest
                     - macos-15-intel
         env:
-            LLVM_SYS_201_PREFIX: /usr/lib/llvm-20
+            LLVM_SYS_221_PREFIX: /usr/lib/llvm-22
 
         steps:
             - name: Checkout
@@ -27,17 +27,18 @@ jobs:
                   # Make sure the actual branch is checked out when running on pull requests
                   ref: ${{ github.head_ref }}
                   repository: ${{github.event.pull_request.head.repo.full_name || github.repository }}
-            - name: Install LLVM dependencies from the cache (Linux)
+            - name: Install LLVM dependencies from APT (Linux)
               if: runner.os == 'Linux'
-              uses: awalsh128/cache-apt-pkgs-action@latest
-              with:
-                  packages: llvm-20 llvm-20-dev libpolly-20-dev clang-20
-                  version: 1.0
+              run: |
+                  wget https://apt.llvm.org/llvm.sh
+                  chmod +x llvm.sh
+                  sudo ./llvm.sh 22
+                  sudo apt install libpolly-22-dev
             - name: Install LLVM dependencies from Homebrew (macOS)
               if: runner.os == 'macOS'
               run: |
-                  brew install llvm@20
-                  echo "LLVM_SYS_201_PREFIX=$(brew --prefix llvm@20)" >> $GITHUB_ENV
+                  brew install llvm@22
+                  echo "LLVM_SYS_221_PREFIX=$(brew --prefix llvm@22)" >> $GITHUB_ENV
             - name: Set up Rust
               uses: actions-rs/toolchain@v1
               with:
@@ -130,7 +131,7 @@ jobs:
               run: make -j2 -C examples test ZRC=zrc LIBZR_DIR=$(pwd)/artifacts/libzr/lib/
     lint-examples:
         needs: build
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-24.04
 
         steps:
             - name: Checkout
@@ -181,7 +182,7 @@ jobs:
                   name: zrc-Debian-${{ runner.arch }}
     comment-artifacts:
         needs: [build, build-debs]
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-24.04
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
 
         steps:
@@ -243,7 +244,7 @@ jobs:
         # only on commits to main
         needs: [build, build-debs]
         if: github.ref == 'refs/heads/main'
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-24.04
         permissions:
             contents: write
         steps:

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -9,9 +9,9 @@ on:
 
 jobs:
     clippy:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-24.04
         env:
-            LLVM_SYS_201_PREFIX: /usr/lib/llvm-20
+            LLVM_SYS_221_PREFIX: /usr/lib/llvm-22
 
         steps:
             - name: Checkout
@@ -20,13 +20,13 @@ jobs:
                   # Make sure the actual branch is checked out when running on pull requests
                   ref: ${{ github.head_ref }}
                   repository: ${{github.event.pull_request.head.repo.full_name || github.repository }}
-            - name: Export LLVM_SYS_201_PREFIX
-              run: echo "LLVM_SYS_201_PREFIX=/usr/lib/llvm-20" >> $GITHUB_ENV
-            - name: Install LLVM dependencies
-              uses: awalsh128/cache-apt-pkgs-action@latest
-              with:
-                  packages: llvm-20 llvm-20-dev libpolly-20-dev clang-20
-                  version: 1.0
+            - name: Install LLVM dependencies from APT (Linux)
+              if: runner.os == 'Linux'
+              run: |
+                  wget https://apt.llvm.org/llvm.sh
+                  chmod +x llvm.sh
+                  sudo ./llvm.sh 22
+                  sudo apt install libpolly-22-dev
             - name: Set up Rust
               uses: actions-rs/toolchain@v1
               with:

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
     fmt:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-24.04
 
         steps:
             - name: Checkout

--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -9,10 +9,10 @@ on:
 
 jobs:
     rustdoc:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-24.04
         env:
             RUSTDOCFLAGS: "-D warnings"
-            LLVM_SYS_201_PREFIX: /usr/lib/llvm-20
+            LLVM_SYS_221_PREFIX: /usr/lib/llvm-22
 
         steps:
             - name: Checkout
@@ -21,11 +21,13 @@ jobs:
                   # Make sure the actual branch is checked out when running on pull requests
                   ref: ${{ github.head_ref }}
                   repository: ${{github.event.pull_request.head.repo.full_name || github.repository }}
-            - name: Install LLVM dependencies
-              uses: awalsh128/cache-apt-pkgs-action@latest
-              with:
-                  packages: llvm-20 llvm-20-dev libpolly-20-dev clang-20
-                  version: 1.0
+            - name: Install LLVM dependencies from APT (Linux)
+              if: runner.os == 'Linux'
+              run: |
+                  wget https://apt.llvm.org/llvm.sh
+                  chmod +x llvm.sh
+                  sudo ./llvm.sh 22
+                  sudo apt install libpolly-22-dev
             - name: Set up Rust
               uses: actions-rs/toolchain@v1
               with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,9 +9,9 @@ on:
 
 jobs:
     test:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-24.04
         env:
-            LLVM_SYS_201_PREFIX: /usr/lib/llvm-20
+            LLVM_SYS_221_PREFIX: /usr/lib/llvm-22
 
         steps:
             - name: Checkout
@@ -20,11 +20,13 @@ jobs:
                   # Make sure the actual branch is checked out when running on pull requests
                   ref: ${{ github.head_ref }}
                   repository: ${{github.event.pull_request.head.repo.full_name || github.repository }}
-            - name: Install LLVM dependencies
-              uses: awalsh128/cache-apt-pkgs-action@latest
-              with:
-                  packages: llvm-20 llvm-20-dev libpolly-20-dev clang-20
-                  version: 1.0
+            - name: Install LLVM dependencies from APT (Linux)
+              if: runner.os == 'Linux'
+              run: |
+                  wget https://apt.llvm.org/llvm.sh
+                  chmod +x llvm.sh
+                  sudo ./llvm.sh 22
+                  sudo apt install libpolly-22-dev
             - name: Set up Rust
               uses: actions-rs/toolchain@v1
               with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -539,9 +539,9 @@ checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "llvm-sys"
-version = "201.0.1"
+version = "221.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bb947e8b79254ca10d496d0798a9ba1287dcf68e50a92b016fec1cc45bef447"
+checksum = "2abcc34a3b190f03c2a61b555f218f529589ff13657bdd2ff8ac3e85f2abe6bb"
 dependencies = [
  "anyhow",
  "cc",

--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ For experienced developers who want to get running quickly:
     # Rust toolchain (if not already installed)
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 
-    # LLVM 20 with Polly + other dependencies (Ubuntu/Debian)
+    # LLVM 22 with Polly + other dependencies (Ubuntu/Debian)
     sudo apt-get update
-    sudo apt-get install -y llvm-20 llvm-20-dev libpolly-20-dev clang-20 build-essential libssl-dev pkg-config libzstd-dev
+    sudo apt-get install -y llvm-22 llvm-22-dev libpolly-22-dev clang-22 build-essential libssl-dev pkg-config libzstd-dev
     ```
 
 2. **Clone and build:**

--- a/compiler/zrc_codegen/Cargo.toml
+++ b/compiler/zrc_codegen/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-inkwell = { version = "0.9.0", features = ["llvm20-1", "llvm20-1-prefer-static"] }
+inkwell = { version = "0.9.0", features = ["llvm22-1", "llvm22-1-prefer-static"] }
 zrc_typeck = { path = "../zrc_typeck" }
 zrc_utils = { path = "../zrc_utils" }
 

--- a/dist/nix/devshell.nix
+++ b/dist/nix/devshell.nix
@@ -19,6 +19,6 @@
       nixfmt
     ];
 
-    LLVM_SYS_201_PREFIX = llvm.llvm.dev;
+    LLVM_SYS_221_PREFIX = llvm.llvm.dev;
   };
 }

--- a/dist/nix/lib.nix
+++ b/dist/nix/lib.nix
@@ -15,7 +15,7 @@
       let
         overlays = [ rust-overlay.overlays.default ];
         pkgs = import nixpkgs { inherit system overlays; };
-        llvm = pkgs.llvmPackages_20;
+        llvm = pkgs.llvmPackages_22;
         rust = pkgs.rust-bin.nightly.latest.default.override {
           extensions = [
             "rust-src"

--- a/dist/nix/pkgs/zrc.nix
+++ b/dist/nix/pkgs/zrc.nix
@@ -35,5 +35,5 @@ naerskLib.buildPackage {
 
   setupHook = ../hooks/zrc.sh;
 
-  LLVM_SYS_201_PREFIX = llvm.llvm.dev;
+  LLVM_SYS_221_PREFIX = llvm.llvm.dev;
 }

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -57,25 +57,25 @@ You should see version information for both commands.
 
 ### 3. LLVM dependencies
 
-Zirco's code generator relies on LLVM 20 for compilation. You need the LLVM static or dynamic library with Polly support.
+Zirco's code generator relies on LLVM 22 for compilation. You need the LLVM static or dynamic library with Polly support.
 
 **Linux (Ubuntu/Debian):**
 
 ```bash
 sudo apt-get update
-sudo apt-get install -y llvm-20 llvm-20-dev libpolly-20-dev clang-20 build-essential libssl-dev pkg-config libzstd-dev
+sudo apt-get install -y llvm-22 llvm-22-dev libpolly-22-dev clang-22 build-essential libssl-dev pkg-config libzstd-dev
 ```
 
 **macOS:**
 
 ```bash
-brew install llvm@20
+brew install llvm@22
 ```
 
 After installation on macOS, you may need to set the LLVM prefix:
 
 ```bash
-export LLVM_SYS_201_PREFIX=$(brew --prefix llvm@20)
+export LLVM_SYS_221_PREFIX=$(brew --prefix llvm@22)
 ```
 
 **Windows:**
@@ -350,28 +350,28 @@ make -C examples test
 
 **Problem:** LLVM Polly library is not installed.
 
-**Solution:** Install the LLVM 16 development libraries:
+**Solution:** Install the LLVM 22 development libraries:
 
 ```bash
 # Ubuntu/Debian:
-sudo apt-get install -y llvm-16 llvm-16-dev libpolly-16-dev
+sudo apt-get install -y llvm-22 llvm-22-dev libpolly-22-dev
 
 # macOS:
-brew install llvm@16
+brew install llvm@22
 ```
 
 ### Build Error: LLVM Not Found
 
-**Problem:** LLVM 16 is installed but the build system can't find it.
+**Problem:** LLVM 22 is installed but the build system can't find it.
 
-**Solution:** Set the `LLVM_SYS_160_PREFIX` environment variable:
+**Solution:** Set the `LLVM_SYS_221_PREFIX` environment variable:
 
 ```bash
 # Linux (typical location):
-export LLVM_SYS_160_PREFIX=/usr/lib/llvm-16
+export LLVM_SYS_221_PREFIX=/usr/lib/llvm-22
 
 # macOS with Homebrew:
-export LLVM_SYS_160_PREFIX=$(brew --prefix llvm@16)
+export LLVM_SYS_221_PREFIX=$(brew --prefix llvm@22)
 
 # Then build:
 cargo build

--- a/flake.lock
+++ b/flake.lock
@@ -59,11 +59,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1779560665,
-        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
+        "lastModified": 1780243769,
+        "narHash": "sha256-x5UQuRsH3MqI0U9afaXSNqzTPSeZlRLvFAav2Ux1pNw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
+        "rev": "331800de5053fcebacf6813adb5db9c9dca22a0c",
         "type": "github"
       },
       "original": {
@@ -118,11 +118,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1780197589,
-        "narHash": "sha256-FVCr2Ij/jKf59a4LW481eeOF6rJRreOBrVgW/aUBTrw=",
+        "lastModified": 1780543271,
+        "narHash": "sha256-oPJ7eJN1sM37v92Rp/eyQL7/rUm0BOvXEBAoq/zN0cM=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "21632e942d89bf1cce4e5a63d7e58a215a0cbfcc",
+        "rev": "c30ca201c5093540cf792f6982f81ba1aa0f3514",
         "type": "github"
       },
       "original": {

--- a/tools/zrx/Cargo.toml
+++ b/tools/zrx/Cargo.toml
@@ -12,6 +12,6 @@ zrc_typeck = { path = "../../compiler/zrc_typeck" }
 zrc_diagnostics = { path = "../../compiler/zrc_diagnostics" }
 zrc_utils = { path = "../../compiler/zrc_utils" }
 zrc_codegen = { path = "../../compiler/zrc_codegen" }
-inkwell = { version = "0.9.0", features = ["llvm20-1", "llvm20-1-prefer-static"] }
+inkwell = { version = "0.9.0", features = ["llvm22-1", "llvm22-1-prefer-static"] }
 clap = { version = "4.5.52", features = ["derive"] }
 zrc_buildinfo = { path = "../../common/zrc_buildinfo" }


### PR DESCRIPTION
LLVM 22 has been out for a few months now and it is time to bump. Tested
on AMD64: unit tests (including codegen snapshots) pass, examples build
and their sanity checks pass and builds run fine in Nix.

Signed-off-by: Logan Devine <logan@zirco.dev>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Quick Start and Getting Started guides to require LLVM 22, with revised Linux/macOS install instructions and environment variable examples.

* **Chores**
  * Updated build and CI configurations and tooling to target the LLVM 22 toolchain across the project.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->