### PR TITLE
repo: remove some stale comment anchors

### DIFF
--- a/compiler/zrc_cli/src/cli.rs
+++ b/compiler/zrc_cli/src/cli.rs
@@ -85,7 +85,6 @@ pub enum FrontendOptLevel {
     #[value(name = "2", alias("default"))]
     O2,
     /// Optimize for fast execution as much as possible.
-    // TODO: does this enable LTO?
     #[value(name = "3", alias("aggressive"))]
     O3,
 }

--- a/compiler/zrc_codegen/src/expr/arithmetic.rs
+++ b/compiler/zrc_codegen/src/expr/arithmetic.rs
@@ -88,7 +88,6 @@ pub fn cg_arithmetic<'ctx, 'input>(
     if let Type::Ptr(pointee) = lhs_ty {
         // Most languages make incrementing a pointer increase the address by the size
         // of the pointee type, hence our use of `gep`.
-        // REVIEW: Is this the approach we want to take?
         #[expect(clippy::wildcard_enum_match_arm)]
         let reg = match op {
             // SAFETY: This can segfault if indices are used incorrectly

--- a/compiler/zrc_codegen/src/program.rs
+++ b/compiler/zrc_codegen/src/program.rs
@@ -199,8 +199,6 @@ pub fn cg_init_fn<'ctx>(
                 .get_file(),
             line_no,
             fn_dbg_subroutine.expect("we have DI"),
-            // REVIEW: Are these values correct? They're the only values that seem to prevent
-            // invalid codegen
             // This is not local to our unit -- it is exported.
             false,
             // This is, in fact, a definition.
@@ -591,8 +589,6 @@ pub fn cg_program_to_string(
             triple,
             cpu,
             "",
-            // FIXME: Does this potentially run the optimizer twice (as we run it ourselves later)?
-            // That may be inefficient.
             optimization_level,
             RelocMode::PIC,
             CodeModel::Default,
@@ -645,9 +641,6 @@ pub fn cg_program_to_string_without_optimization(
             triple,
             cpu,
             "",
-            // FIXME: Technically this function doesn't run optimizations, but we
-            // do run them later in the cg_program function. Does this mean we're making
-            // an invalid target?
             OptimizationLevel::None,
             RelocMode::PIC,
             CodeModel::Default,
@@ -699,8 +692,6 @@ pub fn cg_program_to_buffer(
             triple,
             cpu,
             "",
-            // FIXME: Does this potentially run the optimizer twice (as we run it ourselves later)?
-            // That may be inefficient.
             optimization_level,
             RelocMode::PIC,
             CodeModel::Default,

--- a/compiler/zrc_parser/src/ast/stmt.rs
+++ b/compiler/zrc_parser/src/ast/stmt.rs
@@ -74,7 +74,6 @@ pub enum StmtKind<'input> {
     /// `for (init; cond; post) body`
     ForStmt {
         /// Runs once before the loop starts.
-        // TODO: May also be able to be expressions?
         init: Option<Box<Spanned<Vec<Spanned<LetDeclaration<'input>>>>>>,
         /// Runs before each iteration of the loop. If this evaluates to
         /// `false`, the loop will end. If this is [`None`], the loop

--- a/compiler/zrc_parser/src/lexer.rs
+++ b/compiler/zrc_parser/src/lexer.rs
@@ -583,7 +583,6 @@ pub enum Tok<'input> {
     #[display("\"{_0}\"")]
     StringLiteral(ZrcString<'input>),
     /// Any number literal
-    // FIXME: Do not accept multiple decimal points like "123.456.789"
     #[regex(r"[0-9][0-9\._]*", |lex| NumberLiteral::Decimal(lex.slice()))]
     #[regex(r"0x[0-9a-fA-F_]+", |lex| NumberLiteral::Hexadecimal(&lex.slice()[2..]))]
     #[regex(r"0b[01_]+", |lex| NumberLiteral::Binary(&lex.slice()[2..]))]

--- a/compiler/zrc_typeck/src/typeck/block.rs
+++ b/compiler/zrc_typeck/src/typeck/block.rs
@@ -76,8 +76,6 @@ impl Display for BlockMetadata<'_> {
 ///
 /// # Panics
 /// Panics in some internal state failures.
-// TODO: Maybe the TAST should attach the BlockReturnActuality in each BlockStmt itself and preserve
-// it on sub-blocks in the TAST (this may be helpful in control flow analysis)
 #[expect(clippy::too_many_lines)]
 pub fn type_block<'input>(
     parent_scope: &Scope<'input>,

--- a/compiler/zrc_typeck/src/typeck/expr.rs
+++ b/compiler/zrc_typeck/src/typeck/expr.rs
@@ -16,8 +16,6 @@ use zrc_parser::ast::expr::{Expr, ExprKind};
 use super::scope::Scope;
 use crate::tast::expr::TypedExpr;
 
-// FIXME: this NEEDS to be rewritten to use references almost everywhere and be
-// no-clone. We stack overflow for deep expressions which is VERY VERY BAD.
 /// Type check and infer an [AST expression](Expr) to a [TAST
 /// expression](TypedExpr).
 ///

--- a/compiler/zrc_utils/src/line_finder.rs
+++ b/compiler/zrc_utils/src/line_finder.rs
@@ -8,7 +8,6 @@ pub struct LineAndCol {
     /// The 1-indexed line number
     pub line: u32,
     /// The 1-indexed column number
-    // REVIEW: Is it truly 1-indexed? If it's 0, LLVM in cg will treat it as "no column known"
     pub col: u32,
 }
 

--- a/include/libc/stdlib.zh
+++ b/include/libc/stdlib.zh
@@ -9,13 +9,11 @@ fn free(ptr: *void);
 fn atoi(nptr: *u8) -> i32;
 fn atol(nptr: *u8) -> i64;
 fn atoll(nptr: *u8) -> i64;
-//TODO floats
 //fn atof(nptr: *u8) -> f64;
 fn strtol(nptr: *u8, endptr: **u8, base: i32) -> i64;
 fn strtoll(nptr: *u8, endptr: **u8, base: i32) -> i64;
 fn strtoul(nptr: *u8, endptr: **u8, base: i32) -> u64;
 fn strtoull(nptr: *u8, endptr: **u8, base: i32) -> u64;
-// TODO floats
 //fn strtof(nptr: *u8, endptr: **u8) -> f32;
 //fn strtod(nptr: *u8, endptr: **u8) -> f64;
 //fn strtold(nptr: *u8, endptr: **u8) -> f64;

--- a/tools/zrx/src/cli.rs
+++ b/tools/zrx/src/cli.rs
@@ -59,7 +59,6 @@ pub enum FrontendOptLevel {
     #[value(name = "2", alias("default"))]
     O2,
     /// Optimize for fast execution as much as possible.
-    // TODO: does this enable LTO?
     #[value(name = "3", alias("aggressive"))]
     O3,
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal code cleanup across compiler and tooling modules. Removed obsolete development comments to improve code maintainability.

**Note:** This release contains no user-visible changes or new functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->