### PR TITLE
refactor: use `expect`, not `allow` for clippy lints

### DIFF
--- a/compiler/zrc_codegen/src/ctx.rs
+++ b/compiler/zrc_codegen/src/ctx.rs
@@ -14,7 +14,7 @@ use zrc_utils::line_finder::LineLookup;
 use crate::scope::CgScope;
 
 /// Trait for any context with at least the fields of [`CompilationUnitCtx`]
-#[allow(dead_code)]
+#[expect(dead_code)]
 pub trait AsCompilationUnitCtx<'ctx: 'a, 'a> {
     /// Convert some specific context to a [`CompilationUnitCtx`]
     ///

--- a/compiler/zrc_codegen/src/stmt/loops.rs
+++ b/compiler/zrc_codegen/src/stmt/loops.rs
@@ -109,7 +109,7 @@ pub fn cg_for_stmt<'ctx, 'input, 'a>(
 }
 
 /// Code generates a four statement
-#[allow(clippy::needless_pass_by_value)]
+#[expect(clippy::needless_pass_by_value)]
 pub fn cg_four_stmt<'ctx, 'input, 'a>(
     cg: FunctionCtx<'ctx, 'a>,
     bb: BasicBlock<'ctx>,

--- a/compiler/zrc_parser/src/ast/ty.rs
+++ b/compiler/zrc_parser/src/ast/ty.rs
@@ -73,7 +73,7 @@ pub enum TypeKind<'input> {
 
 // AST builder. We are able to infer the spans of many based on the start of
 // their leftmost and the end of their rightmost operands.
-#[allow(missing_docs, clippy::missing_docs_in_private_items)]
+#[expect(missing_docs)]
 impl<'input> Type<'input> {
     #[must_use]
     pub fn build_ident(ident: Spanned<&'input str>) -> Self {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted lint handling across the compiler to change certain lints from being suppressed to being explicitly expected, improving build diagnostics and making lint findings more visible during development and CI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->