### PR TITLE
fix: do not force unrolling for `four` loops

### DIFF
--- a/compiler/zrc_codegen/src/stmt.rs
+++ b/compiler/zrc_codegen/src/stmt.rs
@@ -222,13 +222,6 @@ pub(crate) fn cg_block<'ctx, 'input, 'a>(
                 post.clone(),
                 body.clone(),
             )),
-            TypedStmtKind::FourStmt(body) => Some(loops::cg_four_stmt(
-                cg,
-                bb,
-                &scope,
-                lexical_block,
-                body.clone(),
-            )),
 
             TypedStmtKind::WhileStmt(cond, body) => Some(loops::cg_while_stmt(
                 cg,

--- a/compiler/zrc_codegen/src/stmt/loops.rs
+++ b/compiler/zrc_codegen/src/stmt/loops.rs
@@ -108,70 +108,6 @@ pub fn cg_for_stmt<'ctx, 'input, 'a>(
     exit
 }
 
-/// Code generates a four statement
-#[expect(clippy::needless_pass_by_value)]
-pub fn cg_four_stmt<'ctx, 'input, 'a>(
-    cg: FunctionCtx<'ctx, 'a>,
-    bb: BasicBlock<'ctx>,
-    scope: &'a CgScope<'input, 'ctx>,
-    lexical_block: Option<DILexicalBlock<'ctx>>,
-    body: Spanned<BlockMetadata<'input>>,
-) -> BasicBlock<'ctx> {
-    let mut current_bb = bb;
-
-    let exit = cg.ctx.append_basic_block(cg.fn_value, "exit");
-
-    // Pre-create all four body blocks so "continue" can target the *next* one.
-    let mut bodies: Vec<BasicBlock<'ctx>> = Vec::with_capacity(4);
-    for i in 0..4 {
-        bodies.push(cg.ctx.append_basic_block(cg.fn_value, &format!("body{i}")));
-    }
-
-    for (i, &body_bb) in bodies.iter().enumerate() {
-        // Branch from the current insertion point to this iteration's body.
-        cg.builder.position_at_end(current_bb);
-        cg.builder
-            .build_unconditional_branch(body_bb)
-            .expect("branch should generate successfully");
-
-        cg.builder.position_at_end(body_bb);
-
-        // If there's a next iteration, `continue` should jump to that iteration's body.
-        // Otherwise, `continue` should jump to exit (no further iterations).
-        let on_continue = if i + 1 < bodies.len() {
-            bodies[i + 1]
-        } else {
-            exit
-        };
-
-        let next_bb = cg_block(
-            cg,
-            body_bb,
-            scope,
-            lexical_block,
-            body.clone(),
-            &Some(LoopBreakaway {
-                on_break: exit,
-                on_continue, // continue jumps to the next iteration's body
-            }),
-        );
-
-        if let Some(next_bb) = next_bb {
-            current_bb = next_bb;
-        } else {
-            // body was unreachable, so we stop generating further iterations
-            return exit;
-        }
-    }
-    cg.builder
-        .build_unconditional_branch(exit)
-        .expect("branch should generate successfully");
-
-    cg.builder.position_at_end(exit);
-
-    exit
-}
-
 /// Code generates a while statement
 pub fn cg_while_stmt<'ctx, 'input, 'a>(
     cg: FunctionCtx<'ctx, 'a>,
@@ -311,6 +247,16 @@ mod tests {
                 let x = 7;
                 if (x == 6) unreachable;
                 else return;
+            }
+        "});
+    }
+
+    #[test]
+    fn four_loop_generates_properly() {
+        cg_snapshot_test!(indoc! {"
+            fn f();
+            fn test() {
+                four f();
             }
         "});
     }

--- a/compiler/zrc_codegen/src/stmt/snapshots/zrc_codegen__stmt__loops__tests__four_loop_generates_properly.snap
+++ b/compiler/zrc_codegen/src/stmt/snapshots/zrc_codegen__stmt__loops__tests__four_loop_generates_properly.snap
@@ -1,0 +1,52 @@
+---
+source: compiler/zrc_codegen/src/stmt/loops.rs
+description: "fn f();\nfn test() {\n    four f();\n}\n"
+expression: resulting_ir
+---
+; ModuleID = 'test.zr'
+source_filename = "test.zr"
+
+declare {} @f()
+
+define {} @test() !dbg !3 {
+entry:
+  %let___four_i = alloca i8, align 1
+  store i8 0, ptr %let___four_i, align 1, !dbg !8
+  br label %header, !dbg !8
+
+header:                                           ; preds = %latch, %entry
+  %load = load i8, ptr %let___four_i, align 1, !dbg !8
+  %cmp = icmp ult i8 %load, 4, !dbg !8
+  br i1 %cmp, label %body, label %exit, !dbg !8
+
+body:                                             ; preds = %header
+  %call = call {} @f(), !dbg !11
+  br label %latch, !dbg !11
+
+latch:                                            ; preds = %body
+  %load1 = load i8, ptr %let___four_i, align 1, !dbg !8
+  %inc = add i8 %load1, 1, !dbg !8
+  store i8 %inc, ptr %let___four_i, align 1, !dbg !8
+  br label %header, !dbg !8
+
+exit:                                             ; preds = %header
+  ret {} zeroinitializer, !dbg !13
+}
+
+!llvm.module.flags = !{!0}
+!llvm.dbg.cu = !{!1}
+
+!0 = !{i32 2, !"Debug Info Version", i32 3}
+!1 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "zrc test runner", isOptimized: false, flags: "zrc --fake-args", runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false)
+!2 = !DIFile(filename: "test.zr", directory: "/fake/path")
+!3 = distinct !DISubprogram(name: "test", linkageName: "test", scope: null, file: !2, line: 2, type: !4, scopeLine: 2, spFlags: DISPFlagDefinition, unit: !1)
+!4 = !DISubroutineType(types: !5)
+!5 = !{!6}
+!6 = !DICompositeType(tag: DW_TAG_structure_type, name: "struct {}", scope: !2, file: !2, elements: !7)
+!7 = !{}
+!8 = !DILocation(line: 3, column: 5, scope: !9)
+!9 = distinct !DILexicalBlock(scope: !10, file: !2, line: 2, column: 11)
+!10 = distinct !DILexicalBlock(scope: !3, file: !2, line: 2, column: 11)
+!11 = !DILocation(line: 3, column: 10, scope: !12)
+!12 = distinct !DILexicalBlock(scope: !9, file: !2, line: 3, column: 10)
+!13 = !DILocation(line: 4, column: 1, scope: !9)

--- a/compiler/zrc_typeck/src/tast/stmt.rs
+++ b/compiler/zrc_typeck/src/tast/stmt.rs
@@ -64,8 +64,6 @@ pub enum TypedStmtKind<'input> {
         /// The body of the loop.
         body: Spanned<BlockMetadata<'input>>,
     },
-    /// `four body`
-    FourStmt(Spanned<BlockMetadata<'input>>),
     /// `switch`
     SwitchCase {
         /// The value to be switched over (`x` in `switch (x) {}`)
@@ -228,18 +226,6 @@ impl Display for TypedStmtKind<'_> {
                         .join("\n"),
                     if_false
                         .value()
-                        .stmts
-                        .iter()
-                        .map(|stmt: &TypedStmt<'_>| indent_lines(&stmt.to_string(), "    "))
-                        .collect::<Vec<_>>()
-                        .join("\n")
-                )
-            }
-            Self::FourStmt(body) => {
-                write!(
-                    f,
-                    "four {{\n{}\n}}",
-                    body.value()
                         .stmts
                         .iter()
                         .map(|stmt: &TypedStmt<'_>| indent_lines(&stmt.to_string(), "    "))

--- a/compiler/zrc_typeck/src/typeck/block/loops.rs
+++ b/compiler/zrc_typeck/src/typeck/block/loops.rs
@@ -2,8 +2,9 @@
 
 use zrc_diagnostics::{Diagnostic, DiagnosticKind, LabelKind, diagnostic::GenericLabel};
 use zrc_parser::ast::{
-    expr::Expr,
+    expr::{Comparison, Expr, ExprKind},
     stmt::{LetDeclaration, Stmt},
+    ty::{Type, TypeKind},
 };
 use zrc_utils::span::{Span, Spannable, Spanned};
 
@@ -105,27 +106,55 @@ pub fn type_four<'input>(
     return_ability: &BlockReturnAbility<'input>,
     stmt_span: Span,
 ) -> Result<Option<(TypedStmt<'input>, BlockReturnActuality)>, Diagnostic> {
-    let loop_scope = scope.clone();
+    // build the following AST:
+    // ```
+    // {
+    //     for (let __four_i = 0u8; __four_i < 4; ++__four_i) {
+    //         body
+    //     }
+    // }
+    // ```
 
-    let body_as_block = coerce_stmt_into_block(*body);
+    let init = Some(Box::new(
+        vec![
+            LetDeclaration {
+                name: "__four_i".in_span(stmt_span),
+                ty: None,
+                value: Some(Expr(
+                    ExprKind::NumberLiteral(
+                        zrc_parser::lexer::NumberLiteral::Decimal("0"),
+                        Some(Type(TypeKind::Identifier("u8").in_span(stmt_span))),
+                    )
+                    .in_span(stmt_span),
+                )),
+                is_constant: false,
+            }
+            .in_span(stmt_span),
+        ]
+        .in_span(stmt_span),
+    ));
+    let cond = Some(Expr(
+        ExprKind::Comparison(
+            Comparison::Lt,
+            Box::new(Expr(ExprKind::Identifier("__four_i").in_span(stmt_span))),
+            Box::new(Expr(
+                ExprKind::NumberLiteral(
+                    zrc_parser::lexer::NumberLiteral::Decimal("4"),
+                    Some(Type(TypeKind::Identifier("u8").in_span(stmt_span))),
+                )
+                .in_span(stmt_span),
+            )),
+        )
+        .in_span(stmt_span),
+    ));
+    let post = Some(Expr(
+        ExprKind::PrefixIncrement(Box::new(Expr(
+            ExprKind::Identifier("__four_i").in_span(stmt_span),
+        )))
+        .in_span(stmt_span),
+    ));
 
-    let body_as_block_span = body_as_block.span();
-
-    let body = type_block(
-        &loop_scope,
-        body_as_block,
-        true,
-        return_ability.clone().demote(),
-    )?;
-    let return_actuality = body.return_actuality;
-
-    Ok(Some((
-        TypedStmt {
-            kind: TypedStmtKind::FourStmt(body.in_span(body_as_block_span)).in_span(stmt_span),
-            return_actuality,
-        },
-        return_actuality,
-    )))
+    type_for(scope, init, cond, post, body, return_ability, stmt_span)
 }
 
 /// Type check a while statement.

--- a/tools/zircop/src/lints/underscore_variable_used.rs
+++ b/tools/zircop/src/lints/underscore_variable_used.rs
@@ -74,6 +74,7 @@ impl<'input> SemanticVisit<'input, '_> for Visit<'input> {
             // are commonly used as private/internal helpers where usage is intentional
             if let Some(first_use) = var_entry.referenced_spans.first()
                 && var_name.starts_with('_')
+                && !var_name.starts_with("__")
                 && !self.reported_vars.contains(&var_name)
                 && !matches!(var_entry.ty, Type::Fn(_))
             {

--- a/tools/zircop/src/visit.rs
+++ b/tools/zircop/src/visit.rs
@@ -424,9 +424,6 @@ pub trait SemanticVisit<'input, 'gs> {
                 }
                 self.visit_tc_block(body.value());
             }
-            TcStmtKind::FourStmt(body) => {
-                self.visit_tc_block(body.value());
-            }
             TcStmtKind::SwitchCase {
                 scrutinee,
                 default,


### PR DESCRIPTION
When `four` was implemented, the trivial solution was to directly code generate the contents four times. When `four` loops were deeply nested, this could explode and create 60+ GB of RAM usage in constructed programs.

This commit desugars `four` to `for` loops, to avoid this same explosion.

Fixes #726

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of `four` loops so they now generate more consistent loop behavior during compilation.
  * Updated the unused-underscore warning to ignore names that start with `__`, reducing false positives.
* **New Features**
  * Added coverage for `four` loop output with a new validation test to help keep generated code stable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->