### PR TITLE
refactor: zpp takes ownership of include paths, remove static references

### DIFF
--- a/compiler/zrc/src/compile.rs
+++ b/compiler/zrc/src/compile.rs
@@ -3,7 +3,7 @@
 //! This module contains the main driver function for the Zirco compiler,
 //! which orchestrates the parsing, type checking, and code generation phases.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use zrc_codegen::{DebugLevel, OptimizationLevel};
 use zrc_parser::parser;
@@ -73,7 +73,7 @@ pub enum OutputFormat {
 )]
 pub fn compile(
     frontend_version_string: &str,
-    include_paths: &[&'static Path],
+    include_paths: Vec<PathBuf>,
     emit: &OutputFormat,
     parent_directory: &str,
     file_name: &str,

--- a/compiler/zrc_cli/src/cli.rs
+++ b/compiler/zrc_cli/src/cli.rs
@@ -182,27 +182,19 @@ fn resolve_include_path(path: &Path) -> PathBuf {
 /// Get the include paths from the CLI environment and -I arguments
 ///
 /// Relative paths are resolved relative to the current working directory.
-pub fn get_include_paths(cli: &Cli) -> Vec<&'static Path> {
+pub fn get_include_paths(cli: &Cli) -> Vec<PathBuf> {
     // append paths in the following order:
     // 1. CLI
     // 2. ZIRCO_INCLUDE_PATH env var
-    let mut include_paths: Vec<&'static Path> = Vec::new();
+    let mut include_paths: Vec<PathBuf> = Vec::new();
 
     for path in &cli.include_paths {
-        let resolved_path = resolve_include_path(path);
-
-        // SAFETY: we leak the PathBuf to get a 'static lifetime
-        let static_path: &'static Path = Box::leak(resolved_path.into_boxed_path());
-        include_paths.push(static_path);
+        include_paths.push(resolve_include_path(path));
     }
 
     if let Ok(env_paths) = std::env::var("ZIRCO_INCLUDE_PATH") {
         for path_str in std::env::split_paths(&env_paths) {
-            let resolved_path = resolve_include_path(&path_str);
-
-            // SAFETY: we leak the PathBuf to get a 'static lifetime
-            let static_path: &'static Path = Box::leak(resolved_path.into_boxed_path());
-            include_paths.push(static_path);
+            include_paths.push(resolve_include_path(&path_str));
         }
     }
 

--- a/compiler/zrc_cli/src/main.rs
+++ b/compiler/zrc_cli/src/main.rs
@@ -123,7 +123,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     let result = compile(
         &version_string(),
-        &cli::get_include_paths(&cli),
+        cli::get_include_paths(&cli),
         &emit.into(),
         &directory_name,
         &file_name,

--- a/compiler/zrc_preprocessor/src/lib.rs
+++ b/compiler/zrc_preprocessor/src/lib.rs
@@ -98,20 +98,20 @@ impl SourceChunk {
 
 /// Context for preprocessing operations
 #[derive(Debug)]
-struct PreprocessorCtx<'sp> {
+struct PreprocessorCtx {
     /// Set of files that have been included with `#pragma once`
     pragma_once_files: HashSet<PathBuf>,
     /// Collected source chunks
     chunks: Vec<SourceChunk>,
     /// The paths to search for bracket includes
-    search_paths: &'sp [&'static Path],
+    search_paths: Vec<PathBuf>,
     /// Whether to forbid includes outside of listed search paths
     forbid_unlisted_includes: bool,
 }
 
-impl<'sp> PreprocessorCtx<'sp> {
+impl PreprocessorCtx {
     /// Create a new preprocessor context
-    fn new(search_paths: &'sp [&'static Path], forbid_unlisted_includes: bool) -> Self {
+    fn new(search_paths: Vec<PathBuf>, forbid_unlisted_includes: bool) -> Self {
         Self {
             pragma_once_files: HashSet::new(),
             chunks: Vec::new(),
@@ -123,7 +123,7 @@ impl<'sp> PreprocessorCtx<'sp> {
 
 /// Search for an include file in the provided search paths
 fn find_include_file(ctx: &PreprocessorCtx, include_file: &str) -> Option<PathBuf> {
-    for search_path in ctx.search_paths {
+    for search_path in &ctx.search_paths {
         let candidate = search_path.join(include_file);
         if candidate.exists() {
             return Some(candidate);
@@ -133,7 +133,7 @@ fn find_include_file(ctx: &PreprocessorCtx, include_file: &str) -> Option<PathBu
 }
 
 /// Check if a resolved path is within any of the allowed search paths
-fn is_path_within_allowed_dirs(resolved_path: &Path, search_paths: &[&Path]) -> bool {
+fn is_path_within_allowed_dirs(resolved_path: &Path, search_paths: &[PathBuf]) -> bool {
     // Try to canonicalize the resolved path
     let Ok(canonical_resolved) = resolved_path.canonicalize() else {
         return false;
@@ -175,11 +175,11 @@ fn is_path_within_allowed_dirs(resolved_path: &Path, search_paths: &[&Path]) -> 
 ///
 /// Panics if the file name cannot be converted to a static string.
 #[expect(clippy::result_large_err)]
-pub fn preprocess(
-    base_path: &Path,
-    search_paths: &'_ [&'static Path],
-    file_name: &str,
-    content: &str,
+pub fn preprocess<'input>(
+    base_path: &'input Path,
+    search_paths: Vec<PathBuf>,
+    file_name: &'input str,
+    content: &'input str,
     forbid_unlisted_includes: bool,
 ) -> Result<Vec<SourceChunk>, Diagnostic> {
     let mut ctx = PreprocessorCtx::new(search_paths, forbid_unlisted_includes);
@@ -376,7 +376,7 @@ fn preprocess_internal(
 
                 // Check if the resolved path is within allowed directories
                 if ctx.forbid_unlisted_includes
-                    && !is_path_within_allowed_dirs(&canonical_path, ctx.search_paths)
+                    && !is_path_within_allowed_dirs(&canonical_path, ctx.search_paths.as_ref())
                 {
                     let sp = Span::from_positions_and_file(
                         current_byte,
@@ -484,7 +484,7 @@ mod tests {
     #[test]
     fn preprocess_simple_file_without_directives() {
         let content = "fn main() {\n    printf(\"Hello\");\n}";
-        let chunks = preprocess(Path::new("."), &[], "test.zr", content, false)
+        let chunks = preprocess(Path::new("."), vec![], "test.zr", content, false)
             .expect("preprocessing failed");
 
         assert_eq!(chunks.len(), 1);
@@ -497,7 +497,7 @@ mod tests {
     #[test]
     fn preprocess_with_pragma_once() {
         let content = "#pragma once\nfn test() {}";
-        let chunks = preprocess(Path::new("."), &[], "test.zr", content, false)
+        let chunks = preprocess(Path::new("."), vec![], "test.zr", content, false)
             .expect("preprocessing failed");
 
         assert_eq!(chunks.len(), 1);
@@ -509,7 +509,7 @@ mod tests {
     #[test]
     fn preprocess_pragma_once_with_multiple_lines() {
         let content = "#pragma once\n\nfn first() {}\nfn second() {}";
-        let chunks = preprocess(Path::new("."), &[], "test.zr", content, false)
+        let chunks = preprocess(Path::new("."), vec![], "test.zr", content, false)
             .expect("preprocessing failed");
 
         assert_eq!(chunks.len(), 1);
@@ -522,7 +522,7 @@ mod tests {
     fn preprocess_tracks_byte_offsets_correctly() {
         // Test that byte offsets are correctly calculated
         let content = "line1\n#pragma once\nline3";
-        let chunks = preprocess(Path::new("."), &[], "test.zr", content, false)
+        let chunks = preprocess(Path::new("."), vec![], "test.zr", content, false)
             .expect("preprocessing failed");
 
         // First chunk: "line1" (before pragma)

--- a/tools/zircop/src/cli.rs
+++ b/tools/zircop/src/cli.rs
@@ -61,25 +61,19 @@ fn resolve_include_path(path: &Path) -> PathBuf {
 /// Get the include paths from the CLI environment and -I arguments
 ///
 /// Relative paths are resolved relative to the current working directory.
-pub fn get_include_paths(cli: &Cli) -> Vec<&'static Path> {
+pub fn get_include_paths(cli: &Cli) -> Vec<PathBuf> {
     // append paths in the following order:
     // 1. CLI
     // 2. ZIRCO_INCLUDE_PATH env var
-    let mut include_paths: Vec<&'static Path> = Vec::new();
+    let mut include_paths: Vec<PathBuf> = Vec::new();
 
     for path in &cli.include_paths {
-        let resolved_path = resolve_include_path(path);
-        // SAFETY: we leak the PathBuf to get a 'static lifetime
-        let static_path: &'static Path = Box::leak(resolved_path.clone().into_boxed_path());
-        include_paths.push(static_path);
+        include_paths.push(resolve_include_path(path));
     }
 
     if let Ok(env_paths) = env::var("ZIRCO_INCLUDE_PATH") {
         for path_str in env::split_paths(&env_paths) {
-            let resolved_path = resolve_include_path(&path_str);
-            // SAFETY: we leak the PathBuf to get a 'static lifetime
-            let static_path: &'static Path = Box::leak(resolved_path.into_boxed_path());
-            include_paths.push(static_path);
+            include_paths.push(resolve_include_path(&path_str));
         }
     }
 

--- a/tools/zircop/src/main.rs
+++ b/tools/zircop/src/main.rs
@@ -94,7 +94,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     input.read_to_string(&mut source_content)?;
 
     let diagnostics = runner::run_with_default_passes(
-        &cli::get_include_paths(&cli),
+        cli::get_include_paths(&cli),
         Path::new(&directory_name),
         &file_name,
         &source_content,

--- a/tools/zircop/src/runner.rs
+++ b/tools/zircop/src/runner.rs
@@ -1,6 +1,6 @@
 //! Execute a list of lints on a program.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use zrc_diagnostics::Diagnostic;
 use zrc_parser::parser;
@@ -11,7 +11,7 @@ use crate::{diagnostic::LintDiagnostic, lints, pass::PassList};
 /// Lint a program with a list of [`crate::lint::Lint`]s.
 #[expect(clippy::result_large_err)]
 pub fn run(
-    include_paths: &[&'static Path],
+    include_paths: Vec<PathBuf>,
     parent_directory: &Path,
     file_name: &str,
     content: &str,
@@ -56,7 +56,7 @@ pub fn run(
 /// [`crate::lints::get_default_lints`].
 #[expect(clippy::result_large_err)]
 pub fn run_with_default_passes(
-    include_paths: &[&'static Path],
+    include_paths: Vec<PathBuf>,
     parent_directory: &Path,
     file_name: &str,
     content: &str,

--- a/tools/zircop/src/test_utils.rs
+++ b/tools/zircop/src/test_utils.rs
@@ -22,7 +22,7 @@ macro_rules! zircop_lint_test {
             let file_name = "<test>";
 
             let lint_result = $crate::runner::run_with_default_passes(
-                &include_paths,
+                include_paths,
                 parent_directory,
                 file_name,
                 $source,

--- a/tools/zrepl/src/cli.rs
+++ b/tools/zrepl/src/cli.rs
@@ -39,27 +39,19 @@ fn resolve_include_path(path: &Path) -> PathBuf {
 /// Get the include paths from the CLI environment and -I arguments
 ///
 /// Relative paths are resolved relative to the current working directory.
-pub fn get_include_paths(cli: &Cli) -> Vec<&'static Path> {
+pub fn get_include_paths(cli: &Cli) -> Vec<PathBuf> {
     // append paths in the following order:
     // 1. CLI
     // 2. ZIRCO_INCLUDE_PATH env var
-    let mut include_paths: Vec<&'static Path> = Vec::new();
+    let mut include_paths: Vec<PathBuf> = Vec::new();
 
     for path in &cli.include_paths {
-        let resolved_path = resolve_include_path(path);
-
-        // SAFETY: we leak the PathBuf to get a 'static lifetime
-        let static_path: &'static Path = Box::leak(resolved_path.into_boxed_path());
-        include_paths.push(static_path);
+        include_paths.push(resolve_include_path(path));
     }
 
     if let Ok(env_paths) = env::var("ZIRCO_INCLUDE_PATH") {
         for path_str in env::split_paths(&env_paths) {
-            let resolved_path = resolve_include_path(&path_str);
-
-            // SAFETY: we leak the PathBuf to get a 'static lifetime
-            let static_path: &'static Path = Box::leak(resolved_path.into_boxed_path());
-            include_paths.push(static_path);
+            include_paths.push(resolve_include_path(&path_str));
         }
     }
 

--- a/tools/zrepl/src/main.rs
+++ b/tools/zrepl/src/main.rs
@@ -55,7 +55,10 @@
 
 mod cli;
 
-use std::{error::Error, path::Path};
+use std::{
+    error::Error,
+    path::{Path, PathBuf},
+};
 
 use clap::Parser;
 use repline::{Response, prebaked::read_and_mut};
@@ -291,7 +294,7 @@ fn handle_help() -> Response {
 }
 
 /// Call the #include cmd (zpp)
-fn handle_include(line: &str, include_paths: &'static [&Path], gs: &mut GlobalScope) -> Response {
+fn handle_include(line: &str, include_paths: Vec<PathBuf>, gs: &mut GlobalScope) -> Response {
     // feed it to the preprocessor
     let chunks = diag_wrapper(
         || zrc_preprocessor::preprocess(Path::new("/dev"), include_paths, "<stdin>", line, false),
@@ -345,7 +348,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     println!();
 
     // Spin up Zirco stuff. Prepare things the preprocessor needs:
-    let include_paths = Box::leak(Box::new(cli::get_include_paths(&cli)));
+    let include_paths = cli::get_include_paths(&cli);
     let mut gs = GlobalScope::new();
     let mut local_scope: Option<typeck::Scope> = None;
 
@@ -422,7 +425,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                     Ok(Response::Accept)
                 }
                 (Mode::Decl, line) if line == "#include" || line.starts_with("#include ") => {
-                    Ok(handle_include(line, include_paths, &mut gs))
+                    Ok(handle_include(line, include_paths.clone(), &mut gs))
                 }
                 (_, line) if line == "#include" || line.starts_with("#include ") => {
                     println!("The #include command is only available in declaration mode.");

--- a/tools/zrx/src/cli.rs
+++ b/tools/zrx/src/cli.rs
@@ -92,27 +92,19 @@ fn resolve_include_path(path: &Path) -> PathBuf {
 /// Get the include paths from the CLI environment and -I arguments
 ///
 /// Relative paths are resolved relative to the current working directory.
-pub fn get_include_paths(cli: &Cli) -> Vec<&'static Path> {
+pub fn get_include_paths(cli: &Cli) -> Vec<PathBuf> {
     // append paths in the following order:
     // 1. CLI
     // 2. ZIRCO_INCLUDE_PATH env var
-    let mut include_paths: Vec<&'static Path> = Vec::new();
+    let mut include_paths: Vec<PathBuf> = Vec::new();
 
     for path in &cli.include_paths {
-        let resolved_path = resolve_include_path(path);
-
-        // SAFETY: we leak the PathBuf to get a 'static lifetime
-        let static_path: &'static Path = Box::leak(resolved_path.into_boxed_path());
-        include_paths.push(static_path);
+        include_paths.push(resolve_include_path(path));
     }
 
     if let Ok(env_paths) = env::var("ZIRCO_INCLUDE_PATH") {
         for path_str in env::split_paths(&env_paths) {
-            let resolved_path = resolve_include_path(&path_str);
-
-            // SAFETY: we leak the PathBuf to get a 'static lifetime
-            let static_path: &'static Path = Box::leak(resolved_path.into_boxed_path());
-            include_paths.push(static_path);
+            include_paths.push(resolve_include_path(&path_str));
         }
     }
 

--- a/tools/zrx/src/main.rs
+++ b/tools/zrx/src/main.rs
@@ -179,7 +179,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
         let chunks = zrc_preprocessor::preprocess(
             Path::new(&directory_name),
-            &include_paths,
+            include_paths.clone(),
             &file_name,
             &source_content,
             false,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved include-path handling across the compiler, REPL, and command-line tools for more reliable file resolution.
  * Preserved include-path precedence while making CLI and environment-based paths behave consistently.
  * Reduced the risk of path-related runtime issues when processing `#include` directives.

* **Refactor**
  * Updated internal path handling to use owned values throughout the toolchain for better stability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->