### PR TITLE
fix(zpp): add error handling to `canonicalize` call

### DIFF
--- a/compiler/zrc_preprocessor/src/lib.rs
+++ b/compiler/zrc_preprocessor/src/lib.rs
@@ -370,9 +370,23 @@ fn preprocess_internal(
                 }
 
                 let include_full_path = base_path.join(&include_file);
-                let canonical_path = include_full_path
-                    .canonicalize()
-                    .expect("failed to canonicalize path");
+                let canonical_path = match include_full_path.canonicalize() {
+                    Ok(path) => path,
+                    Err(err) => {
+                        let sp = Span::from_positions_and_file(
+                            current_byte,
+                            current_byte + line.len(),
+                            static_file_name,
+                        );
+                        return Err(DiagnosticKind::PreprocessorCannotReadIncludeFile
+                            .error_in(sp)
+                            .with_label(GenericLabel::error(
+                                LabelKind::PreprocessorCannotReadIncludeFile(include_file.clone())
+                                    .in_span(sp),
+                            ))
+                            .with_note(NoteKind::ReadFailed(err.to_string())));
+                    }
+                };
 
                 // Check if the resolved path is within allowed directories
                 if ctx.forbid_unlisted_includes


### PR DESCRIPTION
Fixes #698

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Included files that can’t be resolved now produce a clear preprocessor diagnostic instead of causing a crash.
  * The error is shown at the include directive and includes the file name plus the underlying system error for easier troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->