### PR TITLE
Update Cory Borek's profile URL and contributions

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -62,14 +62,15 @@
       "login": "CoryBorek",
       "name": "Cory Borek",
       "avatar_url": "https://avatars.githubusercontent.com/u/27520129?v=4",
-      "profile": "https://agentdid127.com",
+      "profile": "https://coryborek.github.io/",
       "contributions": [
         "ideas",
         "bug",
         "code",
         "platform",
         "maintenance",
-        "plugin"
+        "plugin",
+        "doc"
       ]
     },
     {


### PR DESCRIPTION
Updated profile URL for Cory Borek and added 'doc' to contributions.

I'd prefer my link show my portfolio site, not my main website, as it's a little more useful in this case.

also just putting docs on me (as i've been helping with the spec a bit)