### PR TITLE
feat: packed structs

### DIFF
--- a/book/src/reference.md
+++ b/book/src/reference.md
@@ -215,6 +215,7 @@ type ::= identifier
        | "*" type
        | "[" NUMBER_LITERAL "]" type
        | "struct" "{" field_list? "}"
+       | "packed" "struct" "{" field_list? "}"
        | "union" "{" field_list? "}"
        | "enum" "{" field_list? "}"
        | "fn" "(" field_list? ")" "->" type
@@ -279,7 +280,8 @@ where `N` is a `NUMBER_LITERAL` and `T` is a type.
 
 ### 4.4. Struct Types
 
-Structs are user-defined product types that group named fields together.
+Structs are user-defined product types that group named fields together. They are defined with
+`struct` or `packed struct`.
 
 Structs may be defined inline:
 
@@ -296,7 +298,8 @@ struct Point {
 }
 ```
 
-See Declarations for more information on struct declarations.
+Field ordering is always in declaration order. For `packed struct`s, there is no padding between
+fields. For `struct`s, padding is implementation and architecture defined.
 
 ### 4.5. Union Types
 
@@ -404,11 +407,6 @@ expression with an `i32`.
 
 Zirco uses "duck typing," if a type has the same structure as another type, it is considered to be
 the same type.
-
-### 4.12. Field Ordering/Padding
-
-Field ordering is in declaration order, and padding is implementation defined. Compilers MUST NOT
-reorder fields.
 
 ## 5. Expressions
 
@@ -805,6 +803,7 @@ code path should never be reached, and can be used to optimize code generation.
 program ::= decl*
 
 decl ::= "struct" IDENTIFIER "{" field_decl_list? "}"
+       | "packed" "struct" IDENTIFIER "{" field_decl_list? "}"
        | "union" IDENTIFIER "{" field_decl_list? "}"
        | "enum" IDENTIFIER "{" field_decl_list? "}"
        | "type" IDENTIFIER "=" type ";"

--- a/compiler/zrc_codegen/src/expr/literals.rs
+++ b/compiler/zrc_codegen/src/expr/literals.rs
@@ -145,7 +145,7 @@ pub fn cg_array_literal<'ctx, 'input>(
         | Type::Int
         | Type::Ptr(_)
         | Type::Fn(_)
-        | Type::Struct(_)
+        | Type::Struct { .. }
         | Type::Union(_)
         | Type::Opaque(_) => panic!("array literal must have array type"),
     };

--- a/compiler/zrc_codegen/src/expr/misc.rs
+++ b/compiler/zrc_codegen/src/expr/misc.rs
@@ -144,7 +144,10 @@ pub fn cg_struct_construction<'ctx, 'input>(
     fields: &OrderedValueFields<'input>,
 ) -> BasicBlockAnd<'ctx, BasicValueEnum<'ctx>> {
     match &inferred_type {
-        Type::Struct(field_types) => {
+        Type::Struct {
+            fields: field_types,
+            ..
+        } => {
             // Get the LLVM struct type
             let struct_type = llvm_basic_type(&cg, &inferred_type).0.into_struct_type();
 

--- a/compiler/zrc_codegen/src/expr/place.rs
+++ b/compiler/zrc_codegen/src/expr/place.rs
@@ -84,9 +84,9 @@ pub fn cg_place<'ctx>(
 
         #[expect(clippy::wildcard_enum_match_arm)]
         PlaceKind::Dot(x, prop) => match &x.inferred_type {
-            Type::Struct(contents) => {
+            Type::Struct { fields, .. } => {
                 let x_ty = llvm_basic_type(&cg, &x.inferred_type).0;
-                let prop_idx = contents
+                let prop_idx = fields
                     .iter()
                     .position(|(got_key, _)| *got_key == *prop.into_value())
                     .expect("invalid struct field");

--- a/compiler/zrc_codegen/src/snapshots/zrc_codegen__ty__tests__packed_structs_generate_properly.snap
+++ b/compiler/zrc_codegen/src/snapshots/zrc_codegen__ty__tests__packed_structs_generate_properly.snap
@@ -1,0 +1,28 @@
+---
+source: compiler/zrc_codegen/src/ty.rs
+description: "struct Normal { x: i8, y: i32 }\npacked struct Packed { x: i8, y: i32 }\n\nfn main() -> i32 {\n    let normal: Normal;\n    let pack: Packed;\n    return 0;\n}\n"
+expression: resulting_ir
+---
+; ModuleID = 'test.zr'
+source_filename = "test.zr"
+
+define i32 @main() !dbg !3 {
+entry:
+  %let_pack = alloca <{ i8, i32 }>, align 8
+  %let_normal = alloca { i8, i32 }, align 8
+  ret i32 0, !dbg !7
+}
+
+!llvm.module.flags = !{!0}
+!llvm.dbg.cu = !{!1}
+
+!0 = !{i32 2, !"Debug Info Version", i32 3}
+!1 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "zrc test runner", isOptimized: false, flags: "zrc --fake-args", runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false)
+!2 = !DIFile(filename: "test.zr", directory: "/fake/path")
+!3 = distinct !DISubprogram(name: "main", linkageName: "main", scope: null, file: !2, line: 4, type: !4, scopeLine: 4, spFlags: DISPFlagDefinition, unit: !1)
+!4 = !DISubroutineType(types: !5)
+!5 = !{!6}
+!6 = !DIBasicType(name: "i32")
+!7 = !DILocation(line: 7, column: 12, scope: !8)
+!8 = distinct !DILexicalBlock(scope: !9, file: !2, line: 4, column: 18)
+!9 = distinct !DILexicalBlock(scope: !3, file: !2, line: 4, column: 18)

--- a/compiler/zrc_codegen/src/ty.rs
+++ b/compiler/zrc_codegen/src/ty.rs
@@ -91,7 +91,11 @@ pub fn llvm_int_type<'ctx: 'a, 'a>(
             Type::Int => {
                 panic!("{{int}} type reached code generation, should be resolved in typeck")
             }
-            Type::Ptr(_) | Type::Array { .. } | Type::Fn(_) | Type::Struct(_) | Type::Union(_) => {
+            Type::Ptr(_)
+            | Type::Array { .. }
+            | Type::Fn(_)
+            | Type::Struct { .. }
+            | Type::Union(_) => {
                 panic!("not an integer type")
             }
             Type::Opaque(name) => {
@@ -175,14 +179,14 @@ pub fn llvm_basic_type<'ctx: 'a, 'a>(
         Type::Opaque(name) => {
             panic!("opaque type '{name}' reached code generation, should be resolved in typeck")
         }
-        Type::Struct(fields) => (
+        Type::Struct { fields, packed } => (
             ctx.ctx()
                 .struct_type(
                     &fields
                         .iter()
                         .map(|(_, key_ty)| llvm_basic_type(ctx, key_ty).0)
                         .collect::<Vec<_>>(),
-                    false,
+                    *packed,
                 )
                 .as_basic_type_enum(),
             ctx.dbg_builder().map(|dbg_builder| {
@@ -291,7 +295,7 @@ pub fn llvm_type<'ctx: 'a, 'a>(
         | Type::Usize
         | Type::Isize
         | Type::Ptr(_)
-        | Type::Struct(_)
+        | Type::Struct { .. }
         | Type::Array { .. }
         | Type::Union(_) => {
             let (ty, dbg_ty) = llvm_basic_type(ctx, ty);
@@ -344,6 +348,20 @@ mod tests {
     use indoc::indoc;
 
     use crate::cg_snapshot_test;
+
+    #[test]
+    fn packed_structs_generate_properly() {
+        cg_snapshot_test!(indoc! {"
+            struct Normal { x: i8, y: i32 }
+            packed struct Packed { x: i8, y: i32 }
+
+            fn main() -> i32 {
+                let normal: Normal;
+                let pack: Packed;
+                return 0;
+            }
+        "});
+    }
 
     #[test]
     fn tagged_unions_are_properly_typed() {

--- a/compiler/zrc_parser/src/ast/ty.rs
+++ b/compiler/zrc_parser/src/ast/ty.rs
@@ -52,12 +52,11 @@ pub enum TypeKind<'input> {
         element_type: Box<Type<'input>>,
     },
     /// A direct struct type
-    #[display("{packed}struct {{ {fields} }}")]
+    #[display("{}struct {{ {fields} }}", if *packed { "packed " } else { "" })]
     Struct {
         /// This struct's contents
         fields: KeyTypeMapping<'input>,
         /// True if the struct is a packed struct (no padding between fields)
-        #[display("packed ")]
         packed: bool,
     },
     /// A direct union type
@@ -144,7 +143,7 @@ mod tests {
             "union { a: i32, b: i32 }",
             "enum { Eight: i8, Sixteen: i16 }",
             "fn(x: i32, y: i32) -> i32",
-            "packed struct {}",
+            "packed struct { x: i32 }",
         ];
 
         for input in test_cases {

--- a/compiler/zrc_parser/src/ast/ty.rs
+++ b/compiler/zrc_parser/src/ast/ty.rs
@@ -52,8 +52,14 @@ pub enum TypeKind<'input> {
         element_type: Box<Type<'input>>,
     },
     /// A direct struct type
-    #[display("struct {{ {_0} }}")]
-    Struct(KeyTypeMapping<'input>),
+    #[display("{packed}struct {{ {fields} }}")]
+    Struct {
+        /// This struct's contents
+        fields: KeyTypeMapping<'input>,
+        /// True if the struct is a packed struct (no padding between fields)
+        #[display("packed ")]
+        packed: bool,
+    },
     /// A direct union type
     #[display("union {{ {_0} }}")]
     Union(KeyTypeMapping<'input>),
@@ -87,8 +93,12 @@ impl<'input> Type<'input> {
     }
 
     #[must_use]
-    pub fn build_struct_from_contents(span: Span, keys: KeyTypeMapping<'input>) -> Self {
-        Self(TypeKind::Struct(keys).in_span(span))
+    pub fn build_struct_from_contents(
+        span: Span,
+        fields: KeyTypeMapping<'input>,
+        packed: bool,
+    ) -> Self {
+        Self(TypeKind::Struct { fields, packed }.in_span(span))
     }
 
     #[must_use]
@@ -134,6 +144,7 @@ mod tests {
             "union { a: i32, b: i32 }",
             "enum { Eight: i8, Sixteen: i16 }",
             "fn(x: i32, y: i32) -> i32",
+            "packed struct {}",
         ];
 
         for input in test_cases {

--- a/compiler/zrc_parser/src/internal_parser.lalrpop
+++ b/compiler/zrc_parser/src/internal_parser.lalrpop
@@ -171,9 +171,13 @@ KeyTypeMapping: KeyTypeMapping<'input> = {
 }
 
 StructOrUnionDeclaration: Declaration<'input> = {
+    <a:Spanned<("packed" "struct" <Spanned<IDENTIFIER>> <KeyTypeMapping>)>> => Declaration::TypeAliasDeclaration {
+        name: a.value().0,
+        ty: Type(a.map(|(_, fields)| TypeKind::Struct{ fields, packed: true })),
+    },
     <a:Spanned<("struct" <Spanned<IDENTIFIER>> <KeyTypeMapping>)>> => Declaration::TypeAliasDeclaration {
         name: a.value().0,
-        ty: Type(a.map(|(_, values)| TypeKind::Struct(values))),
+        ty: Type(a.map(|(_, fields)| TypeKind::Struct{ fields, packed: false })),
     },
     <a:Spanned<("union" <Spanned<IDENTIFIER>> <KeyTypeMapping>)>> => Declaration::TypeAliasDeclaration {
         name: a.value().0,
@@ -228,8 +232,10 @@ pub Type: Type<'input> = {
         };
         Type::build_array(spanned!(s, (), e, file_name).span(), size_val, element_type)
     },
+    Spanned<("packed" "struct" <KeyTypeMapping>)> => 
+        Type(<>.map(|fields| TypeKind::Struct { fields, packed: true })),
     Spanned<("struct" <KeyTypeMapping>)> => 
-        Type(<>.map(TypeKind::Struct)),
+        Type(<>.map(|fields| TypeKind::Struct { fields, packed: false })),
     Spanned<("union" <KeyTypeMapping>)> =>
         Type(<>.map(TypeKind::Union)),
     Spanned<("enum" <KeyTypeMapping>)> =>
@@ -254,8 +260,10 @@ TypeOrParenthesizedType: Type<'input> = {
 // This prevents a grammar ambiguity as seen in #553
 ConstructibleType: Type<'input> = {
     Spanned<IDENTIFIER> => Type(<>.map(|x| TypeKind::Identifier(x))),
+    Spanned<("packed" "struct" <KeyTypeMapping>)> => 
+        Type(<>.map(|fields| TypeKind::Struct { fields, packed: true })),
     Spanned<("struct" <KeyTypeMapping>)> => 
-        Type(<>.map(TypeKind::Struct)),
+        Type(<>.map(|fields| TypeKind::Struct { fields, packed: false })),
     Spanned<("union" <KeyTypeMapping>)> =>
         Type(<>.map(TypeKind::Union)),
     Spanned<("enum" <KeyTypeMapping>)> =>
@@ -512,6 +520,7 @@ extern {
         "default" => lexer::Tok::Default,
         "new" => lexer::Tok::New,
         "unreachable" => lexer::Tok::Unreachable,
+        "packed" => lexer::Tok::Packed,
         "->" => lexer::Tok::SmallArrow,
         "<-" => lexer::Tok::SmallArrowBack,
         "=>" => lexer::Tok::FatArrow,

--- a/compiler/zrc_parser/src/lexer.rs
+++ b/compiler/zrc_parser/src/lexer.rs
@@ -545,6 +545,10 @@ pub enum Tok<'input> {
     #[token("unreachable")]
     #[display("unreachable")]
     Unreachable,
+    /// The keyword `packed`
+    #[token("packed")]
+    #[display("packed")]
+    Packed,
     /// The operator `->`
     #[token("->")]
     #[display("->")]
@@ -831,7 +835,7 @@ mod tests {
             " = += -= *= /= %= &= |= ^= ; ,",
             " . : :: ? ( ) [ ] { } true false if else while do for break continue return let fn as",
             r#" struct union enum match sizeof type switch default four -> => "str" 7_000 0xF_A"#,
-            " 0b1_0 abc const"
+            " 0b1_0 abc const packed"
         );
         let tokens: Vec<Tok> = vec![
             Tok::PlusPlus,
@@ -909,6 +913,7 @@ mod tests {
             Tok::NumberLiteral(NumberLiteral::Binary("1_0")),
             Tok::Identifier("abc"),
             Tok::Const,
+            Tok::Packed,
         ];
 
         assert_eq!(

--- a/compiler/zrc_typeck/src/tast/ty.rs
+++ b/compiler/zrc_typeck/src/tast/ty.rs
@@ -122,7 +122,12 @@ pub enum Type<'input> {
     /// `fn(A, B) -> T`
     Fn(Fn<'input>),
     /// Struct type literals. Ordered by declaration order.
-    Struct(OrderedTypeFields<'input>),
+    Struct {
+        /// This struct's contents
+        fields: OrderedTypeFields<'input>,
+        /// True if the struct is a packed struct (no padding between fields)
+        packed: bool,
+    },
     /// Union type literals. Ordered by declaration order.
     Union(OrderedTypeFields<'input>),
     /// Opaque type placeholder used during type resolution for self-referential
@@ -151,10 +156,13 @@ impl Display for Type<'_> {
             Self::Ptr(pointee_ty) => write!(f, "*{pointee_ty}"),
             Self::Array { size, element_type } => write!(f, "[{size}]{element_type}"),
             Self::Fn(fn_data) => write!(f, "{fn_data}"),
-            Self::Struct(fields) if fields.is_empty() => write!(f, "struct {{}}"),
-            Self::Struct(fields) => write!(
+            Self::Struct { packed, fields } if fields.is_empty() => {
+                write!(f, "{}struct {{}}", if *packed { "packed " } else { "" })
+            }
+            Self::Struct { packed, fields } => write!(
                 f,
-                "struct {{ {} }}",
+                "{}struct {{ {} }}",
+                if *packed { "packed " } else { "" },
                 fields
                     .iter()
                     .map(|(key, ty)| format!("{key}: {ty}"))
@@ -216,7 +224,7 @@ impl<'input> Type<'input> {
     #[expect(clippy::wildcard_enum_match_arm)]
     pub fn into_struct_contents(self) -> Option<OrderedTypeFields<'input>> {
         match self {
-            Type::Struct(x) => Some(x),
+            Type::Struct { fields, .. } => Some(fields),
             _ => None,
         }
     }
@@ -234,7 +242,10 @@ impl<'input> Type<'input> {
     /// Get the unit type
     #[must_use]
     pub const fn unit() -> Self {
-        Type::Struct(OrderedTypeFields::new())
+        Type::Struct {
+            fields: OrderedTypeFields::new(),
+            packed: false,
+        }
     }
 
     /// Check if this type can be implicitly cast to the target type.
@@ -265,7 +276,7 @@ impl<'input> Type<'input> {
     pub fn can_implicitly_cast_to(&self, target: &Self) -> bool {
         // Allow any pointer type to implicitly cast to void pointer (*struct{})
         if let (Type::Ptr(_from_pointee), Type::Ptr(to_pointee)) = (self, target)
-            && let Type::Struct(fields) = to_pointee.as_ref()
+            && let Type::Struct { fields, .. } = to_pointee.as_ref()
             && fields.is_empty()
         {
             // Target is *struct{}, allow implicit cast from any *T
@@ -288,15 +299,18 @@ mod tests {
     #[test]
     fn test_void_ptr_implicit_cast() {
         // Create a void pointer type (*struct{})
-        let void_ptr = Type::Ptr(Box::new(Type::Struct(OrderedTypeFields::new())));
+        let void_ptr = Type::Ptr(Box::new(Type::Struct {
+            fields: OrderedTypeFields::new(),
+            packed: false,
+        }));
 
         // Create various pointer types
         let i32_ptr = Type::Ptr(Box::new(Type::I32));
         let bool_ptr = Type::Ptr(Box::new(Type::Bool));
-        let struct_ptr = Type::Ptr(Box::new(Type::Struct(OrderedTypeFields::from(vec![(
-            "x",
-            Type::I8,
-        )]))));
+        let struct_ptr = Type::Ptr(Box::new(Type::Struct {
+            fields: OrderedTypeFields::from(vec![("x", Type::I8)]),
+            packed: false,
+        }));
 
         // All should be able to implicitly cast to void pointer
         assert!(i32_ptr.can_implicitly_cast_to(&void_ptr));
@@ -339,7 +353,10 @@ mod tests {
 
     #[test]
     fn type_display_works_for_empty_struct() {
-        let struct_type = Type::Struct(OrderedTypeFields::new());
+        let struct_type = Type::Struct {
+            fields: OrderedTypeFields::new(),
+            packed: false,
+        };
         assert_eq!(struct_type.to_string(), "struct {}");
     }
 
@@ -363,7 +380,10 @@ mod tests {
     #[test]
     fn into_struct_contents_returns_fields_for_struct() {
         let fields = OrderedTypeFields::from(vec![("x", Type::I32)]);
-        let struct_type = Type::Struct(fields.clone());
+        let struct_type = Type::Struct {
+            fields: fields.clone(),
+            packed: false,
+        };
         assert_eq!(struct_type.into_struct_contents(), Some(fields));
     }
 
@@ -388,7 +408,7 @@ mod tests {
     fn unit_type_is_empty_struct() {
         let unit = Type::unit();
         match unit {
-            Type::Struct(fields) => assert!(fields.is_empty()),
+            Type::Struct { fields, .. } => assert!(fields.is_empty()),
             Type::I8
             | Type::U8
             | Type::I16

--- a/compiler/zrc_typeck/src/typeck/block/switch_match.rs
+++ b/compiler/zrc_typeck/src/typeck/block/switch_match.rs
@@ -221,14 +221,12 @@ pub fn type_match<'input>(
     // * The scrutinee must be of an enum type
     // (Bonus points: Extracts the internal `union` declaration for
     // later use)
-    let enum_as_union_def = if let TastType::Struct(ref struct_def) = scrutinee_ty
-        && struct_def.get("__discriminant__").is_some()
-        && struct_def.get("__value__").is_some()
+    let enum_as_union_def = if let TastType::Struct { ref fields, .. } = scrutinee_ty
+        && fields.get("__discriminant__").is_some()
+        && fields.get("__value__").is_some()
     {
-        if let TastType::Union(union_def) = struct_def
-            .get("__value__")
-            .expect("value should exist")
-            .clone()
+        if let TastType::Union(union_def) =
+            fields.get("__value__").expect("value should exist").clone()
         {
             union_def
         } else {

--- a/compiler/zrc_typeck/src/typeck/expr.rs
+++ b/compiler/zrc_typeck/src/typeck/expr.rs
@@ -110,7 +110,10 @@ mod tests {
                 ("bool", TastType::Bool),
                 (
                     "s",
-                    TastType::Struct(OrderedTypeFields::from(vec![("i8", TastType::I8)])),
+                    TastType::Struct {
+                        fields: OrderedTypeFields::from(vec![("i8", TastType::I8)]),
+                        packed: false,
+                    },
                 ),
                 (
                     "get_bool",
@@ -156,7 +159,10 @@ mod tests {
             ])),
             types: TypeCtx::from_defaults_and_mappings(HashMap::from([(
                 "NonIntegerType",
-                TastType::Struct(OrderedTypeFields::from(vec![])),
+                TastType::Struct {
+                    fields: OrderedTypeFields::from(vec![]),
+                    packed: false,
+                },
             )])),
             ..Default::default()
         };

--- a/compiler/zrc_typeck/src/typeck/expr/access.rs
+++ b/compiler/zrc_typeck/src/typeck/expr/access.rs
@@ -96,7 +96,7 @@ pub fn type_expr_dot<'input>(
     let obj_t = type_expr(scope, obj)?;
     let key_span = key.span();
 
-    if let TastType::Struct(fields) | TastType::Union(fields) = obj_t.inferred_type.clone() {
+    if let TastType::Struct { fields, .. } | TastType::Union(fields) = obj_t.inferred_type.clone() {
         if let Some(ty) = fields.get(key.value()) {
             Ok(TypedExpr {
                 inferred_type: ty.clone(),

--- a/compiler/zrc_typeck/src/typeck/expr/misc.rs
+++ b/compiler/zrc_typeck/src/typeck/expr/misc.rs
@@ -237,7 +237,7 @@ pub fn type_expr_struct_construction<'input>(
     let is_enum = is_enum_literal
         || matches!(
             &resolved_ty,
-            TastType::Struct(fields) if fields.len() == 2
+            TastType::Struct { fields, .. } if fields.len() == 2
                 && fields.contains_key("__discriminant__")
                 && fields.contains_key("__value__")
                 && matches!(fields.get("__value__"), Some(TastType::Union(_)))
@@ -249,7 +249,11 @@ pub fn type_expr_struct_construction<'input>(
         // { ... } } We need to transform: { VariantName: value }
         // Into: { __discriminant__: index, __value__: { VariantName: value } }
 
-        let TastType::Struct(enum_fields) = &resolved_ty else {
+        let TastType::Struct {
+            fields: enum_fields,
+            ..
+        } = &resolved_ty
+        else {
             unreachable!("enum should desugar to a struct")
         };
 
@@ -385,7 +389,7 @@ pub fn type_expr_struct_construction<'input>(
 
     // Ensure it's a struct or union type
     let expected_fields = match &resolved_ty {
-        TastType::Struct(fields) | TastType::Union(fields) => fields.clone(),
+        TastType::Struct { fields, .. } | TastType::Union(fields) => fields.clone(),
         TastType::I8
         | TastType::U8
         | TastType::I16
@@ -499,7 +503,7 @@ pub fn type_expr_struct_construction<'input>(
     }
 
     // For structs (not unions), verify all fields are initialized
-    if matches!(resolved_ty, TastType::Struct(_)) {
+    if matches!(resolved_ty, TastType::Struct { .. }) {
         for (field_name, _field_type) in expected_fields.iter() {
             if !initialized_fields.contains_key(field_name) {
                 return Err(DiagnosticKind::ExpectedGot {

--- a/compiler/zrc_typeck/src/typeck/scope.rs
+++ b/compiler/zrc_typeck/src/typeck/scope.rs
@@ -32,7 +32,13 @@ const fn all_namable_types<'input>() -> [(&'input str, TastType<'input>); 12] {
         ("isize", TastType::Isize),
         ("usize", TastType::Usize),
         ("bool", TastType::Bool),
-        ("void", TastType::Struct(OrderedTypeFields::new())),
+        (
+            "void",
+            TastType::Struct {
+                fields: OrderedTypeFields::new(),
+                packed: false,
+            },
+        ),
     ]
 }
 impl<'input> TypeCtx<'input> {

--- a/compiler/zrc_typeck/src/typeck/ty.rs
+++ b/compiler/zrc_typeck/src/typeck/ty.rs
@@ -51,21 +51,25 @@ pub fn resolve_type<'input>(
             size,
             element_type: Box::new(resolve_type(scope, *element_type)?),
         },
-        ParserTypeKind::Struct(members) => {
-            TastType::Struct(resolve_key_type_mapping(scope, members)?)
-        }
+        ParserTypeKind::Struct { fields, packed } => TastType::Struct {
+            fields: resolve_key_type_mapping(scope, fields)?,
+            packed,
+        },
         ParserTypeKind::Union(members) => {
             TastType::Union(resolve_key_type_mapping(scope, members)?)
         }
         ParserTypeKind::Enum(members) => {
             // Desugar an enum into its represented internal struct
-            TastType::Struct(OrderedTypeFields::from(vec![
-                ("__discriminant__", TastType::Usize),
-                (
-                    "__value__",
-                    (TastType::Union(resolve_key_type_mapping(scope, members)?)),
-                ),
-            ]))
+            TastType::Struct {
+                fields: OrderedTypeFields::from(vec![
+                    ("__discriminant__", TastType::Usize),
+                    (
+                        "__value__",
+                        (TastType::Union(resolve_key_type_mapping(scope, members)?)),
+                    ),
+                ]),
+                packed: false,
+            }
         }
         ParserTypeKind::Function {
             parameters,
@@ -165,11 +169,10 @@ fn resolve_type_with_opaque<'input>(
             size,
             element_type: Box::new(resolve_type_with_opaque(scope, *element_type, opaque_name)?),
         },
-        ParserTypeKind::Struct(members) => TastType::Struct(resolve_key_type_mapping_with_opaque(
-            scope,
-            members,
-            opaque_name,
-        )?),
+        ParserTypeKind::Struct { fields, packed } => TastType::Struct {
+            fields: resolve_key_type_mapping_with_opaque(scope, fields, opaque_name)?,
+            packed,
+        },
         ParserTypeKind::Union(members) => TastType::Union(resolve_key_type_mapping_with_opaque(
             scope,
             members,
@@ -177,17 +180,20 @@ fn resolve_type_with_opaque<'input>(
         )?),
         ParserTypeKind::Enum(members) => {
             // Desugar an enum into its represented internal struct
-            TastType::Struct(OrderedTypeFields::from(vec![
-                ("__discriminant__", TastType::Usize),
-                (
-                    "__value__",
-                    (TastType::Union(resolve_key_type_mapping_with_opaque(
-                        scope,
-                        members,
-                        opaque_name,
-                    )?)),
-                ),
-            ]))
+            TastType::Struct {
+                fields: OrderedTypeFields::from(vec![
+                    ("__discriminant__", TastType::Usize),
+                    (
+                        "__value__",
+                        (TastType::Union(resolve_key_type_mapping_with_opaque(
+                            scope,
+                            members,
+                            opaque_name,
+                        )?)),
+                    ),
+                ]),
+                packed: false,
+            }
         }
         ParserTypeKind::Function {
             parameters,
@@ -254,8 +260,8 @@ fn check_opaque_behind_pointer<'input>(
             // Check the element type for opaque references
             check_opaque_behind_pointer(element_type, opaque_name, ty_span)
         }
-        TastType::Struct(members) | TastType::Union(members) => {
-            for (_, member_ty) in members.iter() {
+        TastType::Struct { fields, .. } | TastType::Union(fields) => {
+            for (_, member_ty) in fields.iter() {
                 check_opaque_behind_pointer(member_ty, opaque_name, ty_span)?;
             }
             Ok(())
@@ -311,12 +317,13 @@ fn replace_opaque_with_concrete<'input>(
             size,
             element_type: Box::new(replace_opaque_with_concrete(*element_type, opaque_name)),
         },
-        TastType::Struct(members) => TastType::Struct(
-            members
+        TastType::Struct { fields, packed } => TastType::Struct {
+            fields: fields
                 .into_iter()
                 .map(|(key, val)| (key, replace_opaque_with_concrete(val, opaque_name)))
                 .collect(),
-        ),
+            packed,
+        },
         TastType::Union(members) => TastType::Union(
             members
                 .into_iter()
@@ -447,43 +454,46 @@ mod tests {
                 &gs.create_subscope(),
                 ParserType(spanned_test!(
                     0,
-                    ParserTypeKind::Struct(KeyTypeMapping(spanned_test!(
-                        7,
-                        vec![
-                            spanned_test!(
-                                9,
-                                (
-                                    spanned_test!(9, "x", 10),
-                                    ParserType(spanned_test!(
-                                        12,
-                                        ParserTypeKind::Identifier("i32"),
-                                        15
-                                    ))
+                    ParserTypeKind::Struct {
+                        fields: KeyTypeMapping(spanned_test!(
+                            7,
+                            vec![
+                                spanned_test!(
+                                    9,
+                                    (
+                                        spanned_test!(9, "x", 10),
+                                        ParserType(spanned_test!(
+                                            12,
+                                            ParserTypeKind::Identifier("i32"),
+                                            15
+                                        ))
+                                    ),
+                                    15
                                 ),
-                                15
-                            ),
-                            spanned_test!(
-                                17,
-                                (
-                                    spanned_test!(17, "y", 18),
-                                    ParserType(spanned_test!(
-                                        20,
-                                        ParserTypeKind::Identifier("i32"),
-                                        23
-                                    ))
-                                ),
-                                23
-                            )
-                        ],
-                        25
-                    ))),
+                                spanned_test!(
+                                    17,
+                                    (
+                                        spanned_test!(17, "y", 18),
+                                        ParserType(spanned_test!(
+                                            20,
+                                            ParserTypeKind::Identifier("i32"),
+                                            23
+                                        ))
+                                    ),
+                                    23
+                                )
+                            ],
+                            25
+                        )),
+                        packed: false
+                    },
                     25
                 ))
             ),
-            Ok(TastType::Struct(OrderedTypeFields::from(vec![
-                ("x", TastType::I32),
-                ("y", TastType::I32)
-            ])))
+            Ok(TastType::Struct {
+                fields: OrderedTypeFields::from(vec![("x", TastType::I32), ("y", TastType::I32)]),
+                packed: false
+            })
         );
     }
 
@@ -529,16 +539,19 @@ mod tests {
                     15
                 ))
             ),
-            Ok(TastType::Struct(OrderedTypeFields::from(vec![
-                ("__discriminant__", TastType::Usize),
-                (
-                    "__value__",
-                    TastType::Union(OrderedTypeFields::from(vec![
-                        ("Eight", TastType::I8),
-                        ("Sixteen", TastType::I16)
-                    ]))
-                )
-            ])))
+            Ok(TastType::Struct {
+                fields: OrderedTypeFields::from(vec![
+                    ("__discriminant__", TastType::Usize),
+                    (
+                        "__value__",
+                        TastType::Union(OrderedTypeFields::from(vec![
+                            ("Eight", TastType::I8),
+                            ("Sixteen", TastType::I16)
+                        ]))
+                    )
+                ]),
+                packed: false
+            })
         );
     }
 
@@ -581,6 +594,7 @@ mod tests {
                         ],
                         25
                     )),
+                    false
                 )
             ),
             Err(Diagnostic::error(spanned_test!(
@@ -605,40 +619,43 @@ mod tests {
             &gs.create_subscope(),
             ParserType(spanned_test!(
                 0,
-                ParserTypeKind::Struct(KeyTypeMapping(spanned_test!(
-                    7,
-                    vec![
-                        spanned_test!(
-                            9,
-                            (
-                                spanned_test!(9, "value", 14),
-                                ParserType(spanned_test!(
-                                    16,
-                                    ParserTypeKind::Identifier("i32"),
-                                    19
-                                ))
+                ParserTypeKind::Struct {
+                    fields: KeyTypeMapping(spanned_test!(
+                        7,
+                        vec![
+                            spanned_test!(
+                                9,
+                                (
+                                    spanned_test!(9, "value", 14),
+                                    ParserType(spanned_test!(
+                                        16,
+                                        ParserTypeKind::Identifier("i32"),
+                                        19
+                                    ))
+                                ),
+                                19
                             ),
-                            19
-                        ),
-                        spanned_test!(
-                            21,
-                            (
-                                spanned_test!(21, "next", 25),
-                                ParserType(spanned_test!(
-                                    27,
-                                    ParserTypeKind::Ptr(Box::new(ParserType(spanned_test!(
-                                        28,
-                                        ParserTypeKind::Identifier("Node"),
+                            spanned_test!(
+                                21,
+                                (
+                                    spanned_test!(21, "next", 25),
+                                    ParserType(spanned_test!(
+                                        27,
+                                        ParserTypeKind::Ptr(Box::new(ParserType(spanned_test!(
+                                            28,
+                                            ParserTypeKind::Identifier("Node"),
+                                            32
+                                        )))),
                                         32
-                                    )))),
-                                    32
-                                ))
-                            ),
-                            32
-                        )
-                    ],
-                    34
-                ))),
+                                    ))
+                                ),
+                                32
+                            )
+                        ],
+                        34
+                    )),
+                    packed: false
+                },
                 34
             )),
             "Node",
@@ -646,7 +663,7 @@ mod tests {
 
         assert!(result.is_ok());
         let resolved_ty = result.expect("should resolve successfully");
-        if let TastType::Struct(fields) = resolved_ty {
+        if let TastType::Struct { fields, .. } = resolved_ty {
             assert_eq!(fields.len(), 2);
             assert_eq!(fields.get("value"), Some(&TastType::I32));
             // The pointer to self should be replaced with pointer to empty struct
@@ -668,36 +685,39 @@ mod tests {
             &gs.create_subscope(),
             ParserType(spanned_test!(
                 0,
-                ParserTypeKind::Struct(KeyTypeMapping(spanned_test!(
-                    7,
-                    vec![
-                        spanned_test!(
-                            9,
-                            (
-                                spanned_test!(9, "value", 14),
-                                ParserType(spanned_test!(
-                                    16,
-                                    ParserTypeKind::Identifier("i32"),
-                                    19
-                                ))
+                ParserTypeKind::Struct {
+                    fields: KeyTypeMapping(spanned_test!(
+                        7,
+                        vec![
+                            spanned_test!(
+                                9,
+                                (
+                                    spanned_test!(9, "value", 14),
+                                    ParserType(spanned_test!(
+                                        16,
+                                        ParserTypeKind::Identifier("i32"),
+                                        19
+                                    ))
+                                ),
+                                19
                             ),
-                            19
-                        ),
-                        spanned_test!(
-                            21,
-                            (
-                                spanned_test!(21, "next", 25),
-                                ParserType(spanned_test!(
-                                    27,
-                                    ParserTypeKind::Identifier("Node"),
-                                    31
-                                ))
-                            ),
-                            31
-                        )
-                    ],
-                    33
-                ))),
+                            spanned_test!(
+                                21,
+                                (
+                                    spanned_test!(21, "next", 25),
+                                    ParserType(spanned_test!(
+                                        27,
+                                        ParserTypeKind::Identifier("Node"),
+                                        31
+                                    ))
+                                ),
+                                31
+                            )
+                        ],
+                        33
+                    )),
+                    packed: false
+                },
                 33
             )),
             "Node",
@@ -729,85 +749,91 @@ mod tests {
             &gs.create_subscope(),
             ParserType(spanned_test!(
                 0,
-                ParserTypeKind::Struct(KeyTypeMapping(spanned_test!(
-                    7,
-                    vec![
-                        spanned_test!(
-                            9,
-                            (
-                                spanned_test!(9, "data", 13),
-                                ParserType(spanned_test!(
-                                    15,
-                                    ParserTypeKind::Identifier("i32"),
-                                    18
-                                ))
+                ParserTypeKind::Struct {
+                    fields: KeyTypeMapping(spanned_test!(
+                        7,
+                        vec![
+                            spanned_test!(
+                                9,
+                                (
+                                    spanned_test!(9, "data", 13),
+                                    ParserType(spanned_test!(
+                                        15,
+                                        ParserTypeKind::Identifier("i32"),
+                                        18
+                                    ))
+                                ),
+                                18
                             ),
-                            18
-                        ),
-                        spanned_test!(
-                            20,
-                            (
-                                spanned_test!(20, "children", 28),
-                                ParserType(spanned_test!(
-                                    30,
-                                    ParserTypeKind::Ptr(Box::new(ParserType(spanned_test!(
-                                        31,
-                                        ParserTypeKind::Struct(KeyTypeMapping(spanned_test!(
-                                            38,
-                                            vec![
-                                                spanned_test!(
-                                                    40,
-                                                    (
-                                                        spanned_test!(40, "item", 44),
-                                                        ParserType(spanned_test!(
-                                                            46,
-                                                            ParserTypeKind::Ptr(Box::new(
+                            spanned_test!(
+                                20,
+                                (
+                                    spanned_test!(20, "children", 28),
+                                    ParserType(spanned_test!(
+                                        30,
+                                        ParserTypeKind::Ptr(Box::new(ParserType(spanned_test!(
+                                            31,
+                                            ParserTypeKind::Struct {
+                                                fields: KeyTypeMapping(spanned_test!(
+                                                    38,
+                                                    vec![
+                                                        spanned_test!(
+                                                            40,
+                                                            (
+                                                                spanned_test!(40, "item", 44),
                                                                 ParserType(spanned_test!(
-                                                                    47,
-                                                                    ParserTypeKind::Identifier(
-                                                                        "Node"
-                                                                    ),
+                                                                    46,
+                                                                    ParserTypeKind::Ptr(Box::new(
+                                                                        ParserType(spanned_test!(
+                                                                        47,
+                                                                        ParserTypeKind::Identifier(
+                                                                            "Node"
+                                                                        ),
+                                                                        51
+                                                                    ))
+                                                                    )),
                                                                     51
                                                                 ))
-                                                            )),
+                                                            ),
                                                             51
-                                                        ))
-                                                    ),
-                                                    51
-                                                ),
-                                                spanned_test!(
-                                                    53,
-                                                    (
-                                                        spanned_test!(53, "next", 57),
-                                                        ParserType(spanned_test!(
-                                                            59,
-                                                            ParserTypeKind::Ptr(Box::new(
+                                                        ),
+                                                        spanned_test!(
+                                                            53,
+                                                            (
+                                                                spanned_test!(53, "next", 57),
                                                                 ParserType(spanned_test!(
-                                                                    60,
-                                                                    ParserTypeKind::Identifier(
-                                                                        "Node"
-                                                                    ),
+                                                                    59,
+                                                                    ParserTypeKind::Ptr(Box::new(
+                                                                        ParserType(spanned_test!(
+                                                                        60,
+                                                                        ParserTypeKind::Identifier(
+                                                                            "Node"
+                                                                        ),
+                                                                        64
+                                                                    ))
+                                                                    )),
                                                                     64
                                                                 ))
-                                                            )),
+                                                            ),
                                                             64
-                                                        ))
-                                                    ),
-                                                    64
-                                                )
-                                            ],
+                                                        )
+                                                    ],
+                                                    66
+                                                )),
+                                                packed: false
+                                            },
                                             66
-                                        ))),
+                                        )))),
                                         66
-                                    )))),
-                                    66
-                                ))
-                            ),
-                            66
-                        )
-                    ],
-                    68
-                ))),
+                                    ))
+                                ),
+                                66
+                            )
+                        ],
+                        68
+                    )),
+                    packed: false
+                },
                 68
             )),
             "Node",

--- a/tools/zircop/src/lints/empty_struct_used.rs
+++ b/tools/zircop/src/lints/empty_struct_used.rs
@@ -50,8 +50,8 @@ impl<'input> SyntacticVisit<'input> for Visit {
 
         let sp = ty.0.span();
 
-        if let TypeKind::Struct(struct_type) = ty.0.value()
-            && struct_type.0.value().is_empty()
+        if let TypeKind::Struct { fields, .. } = ty.0.value()
+            && fields.0.value().is_empty()
         {
             self.diagnostics.push(
                 LintDiagnostic::warning(LintDiagnosticKind::EmptyStructUsed.in_span(sp))


### PR DESCRIPTION
Adds a `packed` field to `TypeKind::Struct`, allowing for packed structs (LLVM: `<{...}>`) to be generated.

Closes #741