### PR TITLE
refactor: make each phase have one unified input type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,4 @@
 [workspace]
-name = "zrc"
 resolver = "2"
 members = [
     "common/zrc_buildinfo",

--- a/compiler/libzrc/src/driver.rs
+++ b/compiler/libzrc/src/driver.rs
@@ -8,7 +8,7 @@ use std::{
 	process, ptr, slice,
 };
 
-use zrc::{OutputFormat, codegen};
+use zrc::{OutputFormat, codegen, compile::CompileInputs};
 
 use crate::diagnostics::ZrcDiagnostic;
 
@@ -104,8 +104,7 @@ pub struct ZrcCompileResult {
 ///   frontend.
 /// * `include_paths` - The list of directories to search for includes.
 /// * `emit` - The desired output format.
-/// * `parent_directory` - The parent directory of the source file.
-/// * `file_name` - The name of the source file.
+/// * `path` - The path of the source file.
 /// * `cli_args` - The command line arguments passed to the compiler.
 /// * `content` - The source code content to be compiled.
 /// * `optimization_level` - The optimization level for code generation.
@@ -131,8 +130,7 @@ pub unsafe extern "C" fn zrc_compile(
 	include_paths: *const *const c_char,
 	include_paths_len: usize,
 	emit: ZrcOutputFormat,
-	parent_directory: *const c_char,
-	file_name: *const c_char,
+	path: *const c_char,
 	cli_args: *const c_char,
 	content: *const c_char,
 	optimization_level: ZrcOptimizationLevel,
@@ -155,12 +153,7 @@ pub unsafe extern "C" fn zrc_compile(
 			)
 		})
 		.collect::<Vec<PathBuf>>();
-	let parent_directory = unsafe { CStr::from_ptr(parent_directory) }
-		.to_string_lossy()
-		.into_owned();
-	let file_name = unsafe { CStr::from_ptr(file_name) }
-		.to_string_lossy()
-		.into_owned();
+	let path = unsafe { PathBuf::from(CStr::from_ptr(path).to_string_lossy().into_owned()) };
 	let cli_args = unsafe { CStr::from_ptr(cli_args) }
 		.to_string_lossy()
 		.into_owned();
@@ -174,22 +167,21 @@ pub unsafe extern "C" fn zrc_compile(
 		.to_string_lossy()
 		.into_owned();
 
-	let result = catch_unwind(|| {
-		zrc::compile(
-			&frontend_version_string,
-			include_paths,
-			&emit.into(),
-			&parent_directory,
-			&file_name,
-			&cli_args,
-			&content,
-			optimization_level.into(),
-			debug_mode.into(),
-			&codegen::TargetTriple::create(&triple),
-			&cpu,
-			forbid_unlisted_includes,
-		)
-	});
+	let compile_inputs = CompileInputs {
+		frontend_version_string: &frontend_version_string,
+		cli_args: &cli_args,
+		include_paths: &include_paths,
+		emit: emit.into(),
+		path: &path,
+		optimization_level: optimization_level.into(),
+		debug_mode: debug_mode.into(),
+		triple: &codegen::TargetTriple::create(&triple),
+		cpu: &cpu,
+		forbid_unlisted_includes,
+		content: &content,
+	};
+
+	let result = catch_unwind(|| zrc::compile(compile_inputs));
 
 	match result {
 		Ok(Ok(output)) => {

--- a/compiler/libzrc/zrc.h
+++ b/compiler/libzrc/zrc.h
@@ -232,8 +232,7 @@ void zrc_diag_free(struct ZrcDiagnostic *diag);
  *   frontend.
  * * `include_paths` - The list of directories to search for includes.
  * * `emit` - The desired output format.
- * * `parent_directory` - The parent directory of the source file.
- * * `file_name` - The name of the source file.
+ * * `path` - The path of the source file.
  * * `cli_args` - The command line arguments passed to the compiler.
  * * `content` - The source code content to be compiled.
  * * `optimization_level` - The optimization level for code generation.
@@ -257,8 +256,7 @@ struct ZrcCompileResult zrc_compile(const char *frontend_version_string,
                                     const char *const *include_paths,
                                     size_t include_paths_len,
                                     ZrcOutputFormat emit,
-                                    const char *parent_directory,
-                                    const char *file_name,
+                                    const char *path,
                                     const char *cli_args,
                                     const char *content,
                                     ZrcOptimizationLevel optimization_level,

--- a/compiler/zrc/src/compile.rs
+++ b/compiler/zrc/src/compile.rs
@@ -3,20 +3,16 @@
 //! This module contains the main driver function for the Zirco compiler,
 //! which orchestrates the parsing, type checking, and code generation phases.
 
-use std::{
-	path::{Path, PathBuf},
-	time::Instant,
-};
+use std::{path::PathBuf, time::Instant};
 
 use tracing::{debug, debug_span, info};
-use zrc_codegen::{DebugLevel, OptimizationLevel};
+use zrc_codegen::{CgProgramInputs, DebugLevel, OptimizationLevel};
 use zrc_parser::parser;
+use zrc_preprocessor::PreprocessInputs;
 use zrc_typeck::typeck;
 
-/// The list of possible outputs `zrc` can emit in
-///
-/// Usually you will want to use `llvm`.
-#[derive(Debug, Clone, PartialEq, Eq)]
+/// The list of possible output file types `zrc` can emit
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum OutputFormat {
 	/// LLVM IR
 	Llvm,
@@ -42,6 +38,65 @@ pub enum OutputFormat {
 	Object,
 }
 
+/// The inputs to the Zirco [`compile`] compilation driver.
+#[derive(Debug)]
+pub struct CompileInputs<'a> {
+	/// A version string for the frontend, used in debug info.
+	pub frontend_version_string: &'a str,
+	/// The CLI arguments passed to the compiler, used in debug info.
+	pub cli_args: &'a str,
+	/// All search paths for global `#include` directives
+	pub include_paths: &'a Vec<PathBuf>,
+	/// The desired output format.
+	pub emit: OutputFormat,
+	/// The path of the source file.
+	pub path: &'a PathBuf,
+	/// The optimization level for code generation.
+	pub optimization_level: OptimizationLevel,
+	/// The debug level for code generation.
+	pub debug_mode: DebugLevel,
+	/// The target triple for code generation.
+	pub triple: &'a zrc_codegen::TargetTriple,
+	/// The target CPU for code generation.
+	pub cpu: &'a str,
+	/// Whether to restrict includes to search paths only.
+	pub forbid_unlisted_includes: bool,
+	/// The content of the source file.
+	pub content: &'a str,
+}
+
+impl<'a> From<&CompileInputs<'a>> for PreprocessInputs<'a> {
+	fn from(val: &CompileInputs<'a>) -> Self {
+		PreprocessInputs {
+			path: val.path,
+			content: val.content,
+			include_paths: val.include_paths,
+			forbid_unlisted_includes: val.forbid_unlisted_includes,
+		}
+	}
+}
+
+impl<'a> From<CompileInputs<'a>> for CgProgramInputs<'a> {
+	fn from(val: CompileInputs<'a>) -> Self {
+		CgProgramInputs {
+			frontend_version_string: val.frontend_version_string,
+			cli_args: val.cli_args,
+			path: val.path,
+			source: val.content,
+			optimization_level: val.optimization_level,
+			debug_level: val.debug_mode,
+			triple: val.triple,
+			cpu: val.cpu,
+			#[expect(clippy::wildcard_enum_match_arm)]
+			file_type: match val.emit {
+				OutputFormat::Asm => zrc_codegen::FileType::Assembly,
+				OutputFormat::Object => zrc_codegen::FileType::Object,
+				_ => unreachable!("file type should only be used for assembly or object"),
+			},
+		}
+	}
+}
+
 /// Drive the compilation process.
 ///
 /// This function takes the source code as input and processes it through
@@ -49,62 +104,18 @@ pub enum OutputFormat {
 /// generation. Depending on the specified output format, it can return the AST,
 /// TAST, LLVM IR, assembly, or object code.
 ///
-/// # Arguments
-///
-/// * `frontend_version_string` - A string representing the version of the
-///   frontend.
-/// * `include_paths` - The list of directories to search for includes.
-/// * `emit` - The desired output format.
-/// * `parent_directory` - The parent directory of the source file.
-/// * `file_name` - The name of the source file.
-/// * `cli_args` - The command line arguments passed to the compiler.
-/// * `content` - The source code content to be compiled.
-/// * `optimization_level` - The optimization level for code generation.
-/// * `debug_mode` - The debug level for code generation.
-/// * `triple` - The target triple for code generation.
-/// * `cpu` - The target CPU for code generation.
-/// * `forbid_unlisted_includes` - Whether to restrict includes to search paths
-///   only.
-///
 /// # Errors
 ///
 /// Err variant contains a [`zrc_diagnostics::Diagnostic`] if any phase of the
 /// compilation fails.
-#[expect(
-	clippy::too_many_arguments,
-	clippy::wildcard_enum_match_arm,
-	clippy::result_large_err,
-	clippy::too_many_lines
-)]
+#[expect(clippy::wildcard_enum_match_arm, clippy::result_large_err)]
 pub fn compile(
-	frontend_version_string: &str,
-	include_paths: Vec<PathBuf>,
-	emit: &OutputFormat,
-	parent_directory: &str,
-	file_name: &str,
-	cli_args: &str,
-	content: &str,
-	optimization_level: OptimizationLevel,
-	debug_mode: DebugLevel,
-	triple: &zrc_codegen::TargetTriple,
-	cpu: &str,
-	forbid_unlisted_includes: bool,
+	inputs @ CompileInputs { emit, .. }: CompileInputs<'_>,
 ) -> Result<Box<[u8]>, zrc_diagnostics::Diagnostic> {
 	// === PREPROCESSOR ===
-	info!(
-		include_paths = ?include_paths,
-		parent_directory = parent_directory,
-		file_name = file_name,
-		"running preprocessor"
-	);
+	info!("running preprocessor");
 	let preprocessor_start = Instant::now();
-	let chunks = zrc_preprocessor::preprocess(
-		Path::new(parent_directory),
-		include_paths,
-		file_name,
-		content,
-		forbid_unlisted_includes,
-	)?;
+	let chunks = zrc_preprocessor::preprocess((&inputs).into())?;
 	debug!(
 		elapsed = ?preprocessor_start.elapsed(),
 		chunk_count = chunks.len(),
@@ -134,7 +145,7 @@ pub fn compile(
 		emit,
 		OutputFormat::Ast | OutputFormat::AstDebug | OutputFormat::AstDebugPretty,
 	) {
-		return Ok(match *emit {
+		return Ok(match emit {
 			OutputFormat::Ast => ast
 				.into_iter()
 				.map(|x| x.to_string())
@@ -163,7 +174,7 @@ pub fn compile(
 		emit,
 		OutputFormat::TastDebug | OutputFormat::TastDebugPretty | OutputFormat::Tast,
 	) {
-		return Ok(match *emit {
+		return Ok(match emit {
 			OutputFormat::TastDebug => format!("{typed_ast:?}"),
 			OutputFormat::TastDebugPretty => format!("{typed_ast:#?}"),
 			OutputFormat::Tast => typed_ast
@@ -183,59 +194,17 @@ pub fn compile(
 	// === CODE GENERATOR ===
 
 	let cg_start = Instant::now();
-	info!(
-		optimization_level = ?optimization_level,
-		debug_mode = ?debug_mode,
-		triple = ?triple,
-		cpu = cpu,
-		"generating code"
-	);
-	let output: Box<[u8]> = match *emit {
-		OutputFormat::Asm => zrc_codegen::cg_program_to_buffer(
-			frontend_version_string,
-			parent_directory,
-			file_name,
-			cli_args,
-			content,
-			typed_ast,
-			zrc_codegen::FileType::Assembly,
-			optimization_level,
-			debug_mode,
-			triple,
-			cpu,
-		)
-		.as_slice()
-		.into(),
-		OutputFormat::Object => zrc_codegen::cg_program_to_buffer(
-			frontend_version_string,
-			parent_directory,
-			file_name,
-			cli_args,
-			content,
-			typed_ast,
-			zrc_codegen::FileType::Object,
-			optimization_level,
-			debug_mode,
-			triple,
-			cpu,
-		)
-		.as_slice()
-		.into(),
+	info!("generating code");
+	let output: Box<[u8]> = match emit {
+		OutputFormat::Asm | OutputFormat::Object => {
+			zrc_codegen::cg_program_to_buffer(inputs.into(), typed_ast)
+				.as_slice()
+				.into()
+		}
 
-		OutputFormat::Llvm => zrc_codegen::cg_program_to_string(
-			frontend_version_string,
-			parent_directory,
-			file_name,
-			cli_args,
-			content,
-			typed_ast,
-			optimization_level,
-			debug_mode,
-			triple,
-			cpu,
-		)
-		.as_bytes()
-		.into(),
+		OutputFormat::Llvm => zrc_codegen::cg_program_to_string(inputs.into(), typed_ast)
+			.as_bytes()
+			.into(),
 
 		// unreachable because we return in the above cases
 		_ => {

--- a/compiler/zrc_cli/src/main.rs
+++ b/compiler/zrc_cli/src/main.rs
@@ -67,7 +67,11 @@ use clap::Parser;
 use cli::Cli;
 use tracing::{debug, info};
 use tracing_subscriber::EnvFilter;
-use zrc::{codegen::DebugLevel, compile, utils::io};
+use zrc::{
+	codegen::DebugLevel,
+	compile::{CompileInputs, compile},
+	utils::io,
+};
 
 use crate::cli::{DiagFormat, FrontendOutputFormat};
 
@@ -108,9 +112,9 @@ fn main() -> Result<(), Box<dyn Error>> {
 		return Err(Box::new(CliError("No input file provided".into())));
 	};
 
-	let (directory_name, file_name, mut input) = io::open_input(path)?;
+	let mut input = io::open_input(path)?;
 
-	debug!(directory_name, file_name, "opened input file");
+	debug!("opened input file");
 
 	let mut source_content = String::new();
 	input.read_to_string(&mut source_content)?;
@@ -146,7 +150,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 			out => {
 				info!(
 					out,
-					"emit type not specified and output file extension not matched, assuming LLVM"
+					"emit type not specified and output file extension not known"
 				);
 				FrontendOutputFormat::Llvm
 			}
@@ -176,20 +180,21 @@ fn main() -> Result<(), Box<dyn Error>> {
 
 	let start = Instant::now();
 
-	let result = compile(
-		&version_string(),
-		include_paths,
-		&emit.into(),
-		&directory_name,
-		&file_name,
-		&std::env::args().collect::<Vec<_>>().join(" "),
-		&source_content,
-		cli.opt_level.into(),
-		debug_level,
-		&target,
-		&cli.cpu,
-		cli.forbid_unlisted_includes,
-	);
+	let inputs = CompileInputs {
+		frontend_version_string: &version_string(),
+		cli_args: &std::env::args().collect::<Vec<_>>().join(" "),
+		include_paths: &include_paths,
+		emit: emit.into(),
+		path,
+		optimization_level: cli.opt_level.into(),
+		debug_mode: debug_level,
+		triple: &target,
+		cpu: &cli.cpu,
+		forbid_unlisted_includes: cli.forbid_unlisted_includes,
+		content: &source_content,
+	};
+
+	let result = compile(inputs);
 
 	match result {
 		Err(diagnostic) => {

--- a/compiler/zrc_codegen/src/lib.rs
+++ b/compiler/zrc_codegen/src/lib.rs
@@ -75,7 +75,7 @@ pub use inkwell::{
 	debug_info::DWARFEmissionKind as DebugLevel,
 	targets::{FileType, TargetTriple},
 };
-pub use program::{cg_program, cg_program_to_buffer, cg_program_to_string};
+pub use program::{CgProgramInputs, cg_program, cg_program_to_buffer, cg_program_to_string};
 
 /// Gets the native [`TargetTriple`].
 #[must_use]

--- a/compiler/zrc_codegen/src/program.rs
+++ b/compiler/zrc_codegen/src/program.rs
@@ -5,7 +5,10 @@
 //! intermediate representation (IR), which can then be optimized and compiled
 //! to machine code.
 
-use std::time::Instant;
+use std::{
+	path::{Path, PathBuf},
+	time::Instant,
+};
 
 use inkwell::{
 	OptimizationLevel,
@@ -295,11 +298,22 @@ fn cg_program_without_optimization<'ctx>(
 	ctx: &'ctx Context,
 	target_machine: &TargetMachine,
 	debug_level: DWARFEmissionKind,
-	parent_directory: &str,
-	file_name: &str,
+	path: &Path,
 	line_lookup: &LineLookup,
 	program: TastRoot<'_>,
 ) -> Module<'ctx> {
+	let parent_directory = path
+		.parent()
+		.expect("source file should have a parent directory")
+		.to_str()
+		.expect("parent directory should be valid UTF-8");
+
+	let file_name = path
+		.file_name()
+		.expect("source file should have a file name")
+		.to_str()
+		.expect("file name should be valid UTF-8");
+
 	let builder = ctx.create_builder();
 	let module = ctx.create_module(file_name);
 
@@ -611,8 +625,7 @@ pub fn cg_program<'ctx>(
 	target_machine: &TargetMachine,
 	optimization_level: OptimizationLevel,
 	debug_level: DWARFEmissionKind,
-	parent_directory: &str,
-	file_name: &str,
+	path: &Path,
 	line_lookup: &LineLookup,
 	program: TastRoot<'_>,
 ) -> Module<'ctx> {
@@ -624,8 +637,7 @@ pub fn cg_program<'ctx>(
 		ctx,
 		target_machine,
 		debug_level,
-		parent_directory,
-		file_name,
+		path,
 		line_lookup,
 		program,
 	);
@@ -645,23 +657,47 @@ pub fn cg_program<'ctx>(
 	module
 }
 
+/// The inputs to [`cg_program_to_buffer`] or [`cg_program_to_string`].
+#[derive(Debug)]
+pub struct CgProgramInputs<'a> {
+	/// A version string for the frontend, used in debug info.
+	pub frontend_version_string: &'a str,
+	/// The CLI arguments passed to the compiler, used in debug info.
+	pub cli_args: &'a str,
+	/// The path of the source file.
+	pub path: &'a PathBuf,
+	/// The source code of the file.
+	pub source: &'a str,
+	/// The optimization level for code generation.
+	pub optimization_level: OptimizationLevel,
+	/// The debug info emission level for code generation.
+	pub debug_level: DWARFEmissionKind,
+	/// The target triple for code generation.
+	pub triple: &'a TargetTriple,
+	/// The target CPU for code generation.
+	pub cpu: &'a str,
+	/// The type of file to generate (e.g., object file, assembly, etc.).
+	pub file_type: FileType,
+}
+
 /// Code generate a LLVM program to a string.
 ///
 /// # Panics
 /// Panics on internal code generation failure.
 #[must_use]
-#[expect(clippy::too_many_arguments)]
 pub fn cg_program_to_string(
-	frontend_version_string: &str,
-	parent_directory: &str,
-	file_name: &str,
-	cli_args: &str,
-	source: &str,
+	CgProgramInputs {
+		frontend_version_string,
+		cli_args,
+		path,
+		source,
+		optimization_level,
+		debug_level,
+		triple,
+		cpu,
+		..
+	}: CgProgramInputs<'_>,
 	program: TastRoot<'_>,
-	optimization_level: OptimizationLevel,
-	debug_level: DWARFEmissionKind,
-	triple: &TargetTriple,
-	cpu: &str,
 ) -> String {
 	let ctx = Context::create();
 
@@ -693,8 +729,7 @@ pub fn cg_program_to_string(
 		&target_machine,
 		optimization_level,
 		debug_level,
-		parent_directory,
-		file_name,
+		path,
 		&LineLookup::new(source),
 		program,
 	);
@@ -709,20 +744,21 @@ pub fn cg_program_to_string(
 /// # Panics
 /// Panics on internal code generation failure.
 #[must_use]
-#[expect(clippy::too_many_arguments)]
 // this function is currently only used in tests because the LLVM optimizer
 // doesn't handle well when multithreaded.
 #[cfg(test)]
 pub fn cg_program_to_string_without_optimization(
-	frontend_version_string: &str,
-	parent_directory: &str,
-	file_name: &str,
-	cli_args: &str,
-	source: &str,
+	CgProgramInputs {
+		frontend_version_string,
+		cli_args,
+		path,
+		source,
+		debug_level,
+		triple,
+		cpu,
+		..
+	}: CgProgramInputs<'_>,
 	program: TastRoot<'_>,
-	debug_level: DWARFEmissionKind,
-	triple: &TargetTriple,
-	cpu: &str,
 ) -> String {
 	let ctx = Context::create();
 
@@ -746,8 +782,7 @@ pub fn cg_program_to_string_without_optimization(
 		&ctx,
 		&target_machine,
 		debug_level,
-		parent_directory,
-		file_name,
+		path,
 		&LineLookup::new(source),
 		program,
 	);
@@ -761,20 +796,20 @@ pub fn cg_program_to_string_without_optimization(
 /// # Panics
 /// Panics on internal code generation failure.
 #[must_use]
-#[expect(clippy::too_many_arguments)]
 #[instrument(skip_all)]
 pub fn cg_program_to_buffer(
-	frontend_version_string: &str,
-	parent_directory: &str,
-	file_name: &str,
-	cli_args: &str,
-	source: &str,
+	CgProgramInputs {
+		frontend_version_string,
+		cli_args,
+		path,
+		source,
+		optimization_level,
+		debug_level,
+		triple,
+		cpu,
+		file_type,
+	}: CgProgramInputs<'_>,
 	program: TastRoot<'_>,
-	file_type: FileType,
-	optimization_level: OptimizationLevel,
-	debug_level: DWARFEmissionKind,
-	triple: &TargetTriple,
-	cpu: &str,
 ) -> MemoryBuffer<'static> {
 	let ctx = Context::create();
 
@@ -806,8 +841,7 @@ pub fn cg_program_to_buffer(
 		&target_machine,
 		optimization_level,
 		debug_level,
-		parent_directory,
-		file_name,
+		path,
 		&LineLookup::new(source),
 		program,
 	);

--- a/compiler/zrc_codegen/src/test_utils.rs
+++ b/compiler/zrc_codegen/src/test_utils.rs
@@ -32,18 +32,21 @@ macro_rules! cg_snapshot_test {
         )
         .expect("typeck should succeed");
 
+        let __zrc_codegen_inputs = $crate::program::CgProgramInputs {
+            frontend_version_string: "zrc test runner",
+            cli_args: "zrc --fake-args",
+            path: &::std::path::PathBuf::from("/fake/path/test.zr"),
+            source: $source,
+            optimization_level: $crate::OptimizationLevel::None,
+            debug_level: ::inkwell::debug_info::DWARFEmissionKind::Full,
+            triple: &$crate::get_native_triple(),
+            cpu: "",
+            file_type: ::inkwell::targets::FileType::Assembly,
+        };
+
         let resulting_ir = $crate::program::cg_program_to_string_without_optimization(
-            "zrc test runner",
-            "/fake/path",
-            "test.zr",
-            // do not use real args because the text executables have a hash in their name and
-            // this would mess up snapshots
-            "zrc --fake-args",
-            $source,
+            __zrc_codegen_inputs,
             __zrc_codegen_typed,
-            ::inkwell::debug_info::DWARFEmissionKind::Full,
-            &$crate::get_native_triple(),
-            "",
         );
 
         insta::with_settings!({

--- a/compiler/zrc_jit/src/module.rs
+++ b/compiler/zrc_jit/src/module.rs
@@ -5,6 +5,7 @@ use std::{
 	ffi::CString,
 	io::{self, ErrorKind},
 	os::raw::c_char,
+	path::Path,
 };
 
 use inkwell::{
@@ -56,13 +57,7 @@ impl<'ctx> JitModule<'ctx> {
 	/// # Panics
 	///
 	/// Panics during internal LLVM failures.
-	pub fn cg_program_and_link(
-		&self,
-		parent_directory: &str,
-		file_name: &str,
-		source_content: &str,
-		typed_ast: TastRoot<'_>,
-	) {
+	pub fn cg_program_and_link(&self, path: &Path, source_content: &str, typed_ast: TastRoot<'_>) {
 		let file_module = cg_program(
 			self.engine.frontend_version_string,
 			self.engine.cli_args,
@@ -70,8 +65,7 @@ impl<'ctx> JitModule<'ctx> {
 			&self.engine.target_machine,
 			OptimizationLevel::Default,
 			zrc_codegen::DebugLevel::None,
-			parent_directory,
-			file_name,
+			path,
 			&LineLookup::new(source_content),
 			typed_ast,
 		);

--- a/compiler/zrc_preprocessor/src/lib.rs
+++ b/compiler/zrc_preprocessor/src/lib.rs
@@ -99,20 +99,20 @@ impl SourceChunk {
 
 /// Context for preprocessing operations
 #[derive(Debug)]
-struct PreprocessorCtx {
+struct PreprocessorCtx<'a> {
 	/// Set of files that have been included with `#pragma once`
 	pragma_once_files: HashSet<PathBuf>,
 	/// Collected source chunks
 	chunks: Vec<SourceChunk>,
 	/// The paths to search for bracket includes
-	search_paths: Vec<PathBuf>,
+	search_paths: &'a Vec<PathBuf>,
 	/// Whether to forbid includes outside of listed search paths
 	forbid_unlisted_includes: bool,
 }
 
-impl PreprocessorCtx {
+impl<'a> PreprocessorCtx<'a> {
 	/// Create a new preprocessor context
-	fn new(search_paths: Vec<PathBuf>, forbid_unlisted_includes: bool) -> Self {
+	fn new(search_paths: &'a Vec<PathBuf>, forbid_unlisted_includes: bool) -> Self {
 		Self {
 			pragma_once_files: HashSet::new(),
 			chunks: Vec::new(),
@@ -124,7 +124,7 @@ impl PreprocessorCtx {
 
 /// Search for an include file in the provided search paths
 fn find_include_file(ctx: &PreprocessorCtx, include_file: &str) -> Option<PathBuf> {
-	for search_path in &ctx.search_paths {
+	for search_path in ctx.search_paths {
 		let candidate = search_path.join(include_file);
 		if candidate.exists() {
 			return Some(candidate);
@@ -154,15 +154,20 @@ fn is_path_within_allowed_dirs(resolved_path: &Path, search_paths: &[PathBuf]) -
 	false
 }
 
+/// The inputs to the Zirco preprocessor.
+#[derive(Debug)]
+pub struct PreprocessInputs<'a> {
+	/// The path of the source file.
+	pub path: &'a PathBuf,
+	/// The content of the source file.
+	pub content: &'a str,
+	/// All search paths for global `#include` directives
+	pub include_paths: &'a Vec<PathBuf>,
+	/// Whether to restrict includes to search paths only.
+	pub forbid_unlisted_includes: bool,
+}
+
 /// Process a Zirco source file with preprocessing directives
-///
-/// # Arguments
-/// * `base_path` - The directory to resolve relative includes from
-/// * `search_paths` - The list of directories to search for includes
-/// * `file_name` - The name of the file being processed
-/// * `content` - The content of the file to preprocess
-/// * `forbid_unlisted_includes` - Whether to restrict includes to search paths
-///   only
 ///
 /// # Errors
 /// Returns an error if:
@@ -177,21 +182,22 @@ fn is_path_within_allowed_dirs(resolved_path: &Path, search_paths: &[PathBuf]) -
 /// Panics if the file name cannot be converted to a static string.
 #[expect(clippy::result_large_err)]
 #[instrument(skip_all)]
-pub fn preprocess<'input>(
-	base_path: &'input Path,
-	search_paths: Vec<PathBuf>,
-	file_name: &'input str,
-	content: &'input str,
-	forbid_unlisted_includes: bool,
+pub fn preprocess(
+	PreprocessInputs {
+		path,
+		content,
+		include_paths,
+		forbid_unlisted_includes,
+	}: PreprocessInputs<'_>,
 ) -> Result<Vec<SourceChunk>, Diagnostic> {
-	let mut ctx = PreprocessorCtx::new(search_paths, forbid_unlisted_includes);
-
 	debug!(
-		base_path = ?base_path,
-		file_name = file_name,
-		search_paths = ?ctx.search_paths,
+		base_path = ?path.parent().unwrap_or_else(|| Path::new("")),
+		file_name = path.to_str(),
+		include_paths = ?include_paths,
 		"starting preprocessing"
 	);
+
+	let mut ctx = PreprocessorCtx::new(include_paths, forbid_unlisted_includes);
 
 	// Trim off a leading shebang line if present
 	let content = if content.starts_with("#!") {
@@ -204,13 +210,7 @@ pub fn preprocess<'input>(
 			let sp = Span::from_positions_and_file(
 				0,
 				shebang_len,
-				Box::leak(
-					base_path
-						.join(file_name)
-						.to_string_lossy()
-						.into_owned()
-						.into_boxed_str(),
-				),
+				Box::leak(path.to_str().expect("path should be valid").into()),
 			);
 			return Err(DiagnosticKind::PreprocessorInvalidShebang
 				.error_in(sp)
@@ -227,7 +227,15 @@ pub fn preprocess<'input>(
 		content
 	};
 
-	preprocess_internal(base_path, file_name, content, &mut ctx)?;
+	preprocess_internal(
+		path.parent().unwrap_or_else(|| Path::new("")),
+		path.file_name()
+			.expect("should have a file name")
+			.to_str()
+			.expect("should be valid"),
+		content,
+		&mut ctx,
+	)?;
 	Ok(ctx.chunks)
 }
 
@@ -518,8 +526,13 @@ mod tests {
 	#[test]
 	fn preprocess_simple_file_without_directives() {
 		let content = "fn main() {\n    printf(\"Hello\");\n}";
-		let chunks = preprocess(Path::new("."), vec![], "test.zr", content, false)
-			.expect("preprocessing failed");
+		let chunks = preprocess(PreprocessInputs {
+			include_paths: &vec![],
+			path: &PathBuf::from("./test.zr"),
+			content,
+			forbid_unlisted_includes: false,
+		})
+		.expect("preprocessing failed");
 
 		assert_eq!(chunks.len(), 1);
 		assert_eq!(chunks[0].file_name, "./test.zr");
@@ -531,8 +544,13 @@ mod tests {
 	#[test]
 	fn preprocess_with_pragma_once() {
 		let content = "#pragma once\nfn test() {}";
-		let chunks = preprocess(Path::new("."), vec![], "test.zr", content, false)
-			.expect("preprocessing failed");
+		let chunks = preprocess(PreprocessInputs {
+			include_paths: &vec![],
+			path: &PathBuf::from("./test.zr"),
+			content,
+			forbid_unlisted_includes: false,
+		})
+		.expect("preprocessing failed");
 
 		assert_eq!(chunks.len(), 1);
 		assert_eq!(chunks[0].start_line, 2);
@@ -543,8 +561,13 @@ mod tests {
 	#[test]
 	fn preprocess_pragma_once_with_multiple_lines() {
 		let content = "#pragma once\n\nfn first() {}\nfn second() {}";
-		let chunks = preprocess(Path::new("."), vec![], "test.zr", content, false)
-			.expect("preprocessing failed");
+		let chunks = preprocess(PreprocessInputs {
+			include_paths: &vec![],
+			path: &PathBuf::from("./test.zr"),
+			content,
+			forbid_unlisted_includes: false,
+		})
+		.expect("preprocessing failed");
 
 		assert_eq!(chunks.len(), 1);
 		assert_eq!(chunks[0].start_line, 2);
@@ -556,8 +579,13 @@ mod tests {
 	fn preprocess_tracks_byte_offsets_correctly() {
 		// Test that byte offsets are correctly calculated
 		let content = "line1\n#pragma once\nline3";
-		let chunks = preprocess(Path::new("."), vec![], "test.zr", content, false)
-			.expect("preprocessing failed");
+		let chunks = preprocess(PreprocessInputs {
+			include_paths: &vec![],
+			path: &PathBuf::from("./test.zr"),
+			content,
+			forbid_unlisted_includes: false,
+		})
+		.expect("preprocessing failed");
 
 		// First chunk: "line1" (before pragma)
 		assert_eq!(chunks.len(), 2);

--- a/compiler/zrc_utils/src/io.rs
+++ b/compiler/zrc_utils/src/io.rs
@@ -28,31 +28,15 @@ use tracing::{debug, instrument};
 ///
 /// If the file name or directory name cannot be converted to a valid string.
 #[instrument]
-pub fn open_input(path: &PathBuf) -> Result<(String, String, Box<dyn Read>), io::Error> {
+pub fn open_input(path: &PathBuf) -> Result<Box<dyn Read>, io::Error> {
 	if path.as_os_str() == "-" {
 		debug!("reading from standard input");
-		Ok((
-			"/dev".to_string(),
-			"<stdin>".to_string(),
-			Box::new(io::stdin()),
-		))
+		Ok(Box::new(io::stdin()))
 	} else {
 		let file = fs::File::open(path)?;
-		let mut canonical = fs::canonicalize(path)?;
-		debug!(canonical_path = ?canonical, "opening input");
-		let file_name = canonical
-			.file_name()
-			.expect("file name should exist")
-			.to_str()
-			.expect("should be a valid str")
-			.to_string();
-		canonical.pop();
-		let directory_name = canonical
-			.to_str()
-			.expect("directory should be a valid str")
-			.to_string();
+		debug!(path = ?path, "opening input");
 
-		Ok((directory_name, file_name, Box::new(file)))
+		Ok(Box::new(file))
 	}
 }
 
@@ -81,64 +65,4 @@ pub fn open_output(path: &PathBuf) -> Result<Box<dyn io::Write>, io::Error> {
 				.open(path)?,
 		)
 	})
-}
-
-#[cfg(test)]
-mod tests {
-	use std::io::Write;
-
-	use super::*;
-
-	#[test]
-	fn open_input_reads_from_stdin_for_dash() {
-		let path = PathBuf::from("-");
-		let result = open_input(&path);
-		assert!(result.is_ok());
-		let (dir, file, _reader) = result.expect("should succeed");
-		assert_eq!(dir, "/dev");
-		assert_eq!(file, "<stdin>");
-	}
-
-	#[test]
-	fn open_input_reads_from_file() {
-		let temp_file = std::env::temp_dir().join("test_input.zrc");
-		fs::write(&temp_file, "test content").expect("should write test file");
-
-		let result = open_input(&temp_file);
-		assert!(result.is_ok());
-
-		let (dir, file, mut reader) = result.expect("should succeed");
-		assert_eq!(file, "test_input.zrc");
-		assert_ne!(dir, "");
-
-		let mut content = String::new();
-		reader.read_to_string(&mut content).expect("should read");
-		assert_eq!(content, "test content");
-
-		fs::remove_file(&temp_file).expect("should cleanup test file");
-	}
-
-	#[test]
-	fn open_output_writes_to_stdout_for_dash() {
-		let path = PathBuf::from("-");
-		let result = open_output(&path);
-		assert!(result.is_ok());
-	}
-
-	#[test]
-	fn open_output_creates_file() {
-		let temp_file = std::env::temp_dir().join("test_output.zrc");
-
-		let result = open_output(&temp_file);
-		assert!(result.is_ok());
-
-		let mut writer = result.expect("should succeed");
-		writer.write_all(b"test output").expect("should write");
-		drop(writer);
-
-		let content = fs::read_to_string(&temp_file).expect("should read file");
-		assert_eq!(content, "test output");
-
-		fs::remove_file(&temp_file).expect("should cleanup test file");
-	}
 }

--- a/tools/zircop/src/main.rs
+++ b/tools/zircop/src/main.rs
@@ -54,7 +54,7 @@
 
 mod cli;
 
-use std::{error::Error, fmt, path::Path, process, time::Instant};
+use std::{error::Error, fmt, process, time::Instant};
 
 use clap::Parser;
 use cli::Cli;
@@ -95,7 +95,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 		return Err(Box::new(CliError("No input file specified.".into())));
 	};
 
-	let (directory_name, file_name, mut input) = io::open_input(path)?;
+	let mut input = io::open_input(path)?;
 
 	let mut source_content = String::new();
 	input.read_to_string(&mut source_content)?;
@@ -105,9 +105,8 @@ fn main() -> Result<(), Box<dyn Error>> {
 	let start = Instant::now();
 	debug!("running linter");
 	let diagnostics = runner::run_with_default_passes(
-		cli::get_include_paths(&cli),
-		Path::new(&directory_name),
-		&file_name,
+		&cli::get_include_paths(&cli),
+		path,
 		&source_content,
 		cli.forbid_unlisted_includes,
 	);

--- a/tools/zircop/src/runner.rs
+++ b/tools/zircop/src/runner.rs
@@ -1,13 +1,11 @@
 //! Execute a list of lints on a program.
 
-use std::{
-	path::{Path, PathBuf},
-	time::Instant,
-};
+use std::{path::PathBuf, time::Instant};
 
 use tracing::{debug, info};
 use zrc_diagnostics::Diagnostic;
 use zrc_parser::parser;
+use zrc_preprocessor::PreprocessInputs;
 use zrc_typeck::typeck;
 
 use crate::{diagnostic::LintDiagnostic, lints, pass::PassList};
@@ -15,9 +13,8 @@ use crate::{diagnostic::LintDiagnostic, lints, pass::PassList};
 /// Lint a program with a list of [`crate::lint::Lint`]s.
 #[expect(clippy::result_large_err)]
 pub fn run(
-	include_paths: Vec<PathBuf>,
-	parent_directory: &Path,
-	file_name: &str,
+	include_paths: &Vec<PathBuf>,
+	path: &PathBuf,
 	content: &str,
 	forbid_unlisted_includes: bool,
 	passes: &PassList,
@@ -29,13 +26,13 @@ pub fn run(
 
 	// === PREPROCESSOR ===
 	info!("running preprocessor");
-	let chunks = zrc_preprocessor::preprocess(
-		parent_directory,
-		include_paths,
-		file_name,
+
+	let chunks = zrc_preprocessor::preprocess(PreprocessInputs {
+		path,
 		content,
+		include_paths,
 		forbid_unlisted_includes,
-	)?;
+	})?;
 
 	// === PARSER ===
 	info!("parsing source code");
@@ -69,17 +66,15 @@ pub fn run(
 /// [`crate::lints::get_default_lints`].
 #[expect(clippy::result_large_err)]
 pub fn run_with_default_passes(
-	include_paths: Vec<PathBuf>,
-	parent_directory: &Path,
-	file_name: &str,
+	include_paths: &Vec<PathBuf>,
+	path: &PathBuf,
 	content: &str,
 	forbid_unlisted_includes: bool,
 ) -> Result<Vec<LintDiagnostic>, Diagnostic> {
 	let passes = lints::get_default_lints();
 	run(
 		include_paths,
-		parent_directory,
-		file_name,
+		path,
 		content,
 		forbid_unlisted_includes,
 		&passes,

--- a/tools/zircop/src/test_utils.rs
+++ b/tools/zircop/src/test_utils.rs
@@ -18,17 +18,11 @@ macro_rules! zircop_lint_test {
 		#[test]
 		fn $name() {
 			let include_paths = vec![];
-			let parent_directory = std::path::Path::new("");
-			let file_name = "<test>";
+			let path = ::std::path::PathBuf::from("<test>");
 
-			let lint_result = $crate::runner::run_with_default_passes(
-				include_paths,
-				parent_directory,
-				file_name,
-				$source,
-				false,
-			)
-			.expect("Compilation should succeed");
+			let lint_result =
+				$crate::runner::run_with_default_passes(&include_paths, &path, $source, false)
+					.expect("Compilation should succeed");
 
 			assert_eq!(
 				lint_result, $diagnostics,

--- a/tools/zrepl/src/main.rs
+++ b/tools/zrepl/src/main.rs
@@ -55,15 +55,13 @@
 
 mod cli;
 
-use std::{
-	error::Error,
-	path::{Path, PathBuf},
-};
+use std::{error::Error, path::PathBuf};
 
 use clap::Parser;
 use repline::{Response, prebaked::read_and_mut};
 use tracing_subscriber::EnvFilter;
 use zrc_parser::{lexer, parser};
+use zrc_preprocessor::PreprocessInputs;
 use zrc_typeck::typeck::{self, GlobalScope};
 
 use crate::cli::Cli;
@@ -295,12 +293,15 @@ fn handle_help() -> Response {
 }
 
 /// Call the #include cmd (zpp)
-fn handle_include(line: &str, include_paths: Vec<PathBuf>, gs: &mut GlobalScope) -> Response {
+fn handle_include(line: &str, include_paths: &Vec<PathBuf>, gs: &mut GlobalScope) -> Response {
 	// feed it to the preprocessor
-	let chunks = diag_wrapper(
-		|| zrc_preprocessor::preprocess(Path::new("/dev"), include_paths, "<stdin>", line, false),
-		Some(line),
-	);
+	let zpp_inputs = PreprocessInputs {
+		path: &PathBuf::from("/dev/<stdin>"),
+		content: line,
+		include_paths,
+		forbid_unlisted_includes: false,
+	};
+	let chunks = diag_wrapper(|| zrc_preprocessor::preprocess(zpp_inputs), Some(line));
 	let Ok(chunks) = chunks else {
 		// Repline does not like it when you Continue or Reject after printing
 		return Response::Accept;
@@ -429,7 +430,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 					Ok(Response::Accept)
 				}
 				(Mode::Decl, line) if line == "#include" || line.starts_with("#include ") => {
-					Ok(handle_include(line, include_paths.clone(), &mut gs))
+					Ok(handle_include(line, &include_paths, &mut gs))
 				}
 				(_, line) if line == "#include" || line.starts_with("#include ") => {
 					println!("The #include command is only available in declaration mode.");

--- a/tools/zrx/src/main.rs
+++ b/tools/zrx/src/main.rs
@@ -52,19 +52,14 @@
 	clippy::missing_errors_doc
 )]
 
-use std::{
-	env,
-	error::Error,
-	fmt,
-	path::{Path, PathBuf},
-	process,
-};
+use std::{env, error::Error, fmt, path::PathBuf, process};
 
 use clap::Parser;
 use tracing::{debug, debug_span};
 use tracing_subscriber::EnvFilter;
 use zrc_jit::engine::JitEngine;
 use zrc_parser::parser;
+use zrc_preprocessor::PreprocessInputs;
 use zrc_typeck::typeck;
 use zrc_utils::io;
 
@@ -119,18 +114,18 @@ fn main() -> Result<(), Box<dyn Error>> {
 	for path in all_files {
 		let _span = debug_span!("jit_file", path = ?path).entered();
 
-		let (directory_name, file_name, mut input) = io::open_input(&path)?;
+		let mut input = io::open_input(&path)?;
 
 		let mut source_content = String::new();
 		input.read_to_string(&mut source_content)?;
 
-		let chunks = zrc_preprocessor::preprocess(
-			Path::new(&directory_name),
-			include_paths.clone(),
-			&file_name,
-			&source_content,
-			false,
-		)?;
+		let zpp_inputs = PreprocessInputs {
+			path: &path,
+			content: &source_content,
+			include_paths: &include_paths,
+			forbid_unlisted_includes: false,
+		};
+		let chunks = zrc_preprocessor::preprocess(zpp_inputs)?;
 
 		let mut ast = Vec::new();
 		for chunk in &chunks {
@@ -141,7 +136,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 		let mut global_scope = typeck::GlobalScope::new();
 		let typed_ast = typeck::type_program(&mut global_scope, ast)?;
 
-		module.cg_program_and_link(&directory_name, &file_name, &source_content, typed_ast);
+		module.cg_program_and_link(&path, &source_content, typed_ast);
 	}
 
 	for lib in &cli.libraries {


### PR DESCRIPTION
Instead of every phase taking 400 individual arguments, every phase has
its own input type which is constructed by the top level driver's input
struct.
