### PR TITLE
repo: drop builds for Intel macOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,6 @@ jobs:
                     - ubuntu-24.04
                     - ubuntu-24.04-arm
                     - macos-latest
-                    - macos-15-intel
         env:
             LLVM_SYS_221_PREFIX: /usr/lib/llvm-22
 
@@ -206,7 +205,6 @@ jobs:
                       - **Linux x64**: \`zrc-Linux-X64-release\`
                       - **Linux ARM64**: \`zrc-Linux-ARM64-release\`
                       - **macOS ARM64**: \`zrc-macOS-ARM64-release\`
-                      - **macOS x64**: \`zrc-macOS-X64-release\`
 
                       If you use the [Zircon toolchain manager](https://github.com/zirco-lang/zircon), you can easily install the built artifacts using these downloaded packages:
                       \`\`\`bash
@@ -220,8 +218,8 @@ jobs:
                           repo: context.repo.repo,
                       });
 
-                      const botComment = comments.data.find(comment => 
-                          comment.user.type === 'Bot' && 
+                      const botComment = comments.data.find(comment =>
+                          comment.user.type === 'Bot' &&
                           comment.body.includes('🚀 **Build Artifacts**')
                       );
 
@@ -293,11 +291,6 @@ jobs:
               with:
                   name: zrc-Linux-ARM64-release
                   path: Linux-ARM64
-            - name: Download X86 macOS build artifact
-              uses: actions/download-artifact@v8
-              with:
-                  name: zrc-macOS-X64-release
-                  path: macOS-X64
             - name: Download ARM64 macOS build artifact
               uses: actions/download-artifact@v8
               with:
@@ -317,13 +310,11 @@ jobs:
               run: |
                   chmod +x Linux-X64/bin/*
                   chmod +x Linux-ARM64/bin/*
-                  chmod +x macOS-X64/bin/*
                   chmod +x macOS-ARM64/bin/*
             - name: Create tar archives
               run: |
                   tar -czf zrc-linux-x64.tar.gz -C Linux-X64 .
                   tar -czf zrc-linux-arm64.tar.gz -C Linux-ARM64 .
-                  tar -czf zrc-macos-x64.tar.gz -C macOS-X64 .
                   tar -czf zrc-macos-arm64.tar.gz -C macOS-ARM64 .
                   mv Debian-X64/* .
                   mv Debian-ARM64/* .
@@ -348,7 +339,6 @@ jobs:
                   files: |
                       zrc-linux-x64.tar.gz
                       zrc-linux-arm64.tar.gz
-                      zrc-macos-x64.tar.gz
                       zrc-macos-arm64.tar.gz
                       *.deb
 

--- a/book/src/ch01-01-installation.md
+++ b/book/src/ch01-01-installation.md
@@ -12,14 +12,17 @@ The toolchain has host support for the following targets:
 **Tier 2 targets** (built, but not tested in CI):
 
 - `aarch64-unknown-linux-gnu` (Linux on ARM64, prebuilt binaries available)
-- `x86_64-apple-darwin` (macOS on x86_64, prebuilt binaries available, **deprecated**)
 - `aarch64-apple-darwin` (macOS on Apple Silicon, prebuilt binaries available)
+- Nix `aarch64-linux`
 
-> [!NOTE]
-> Nix support for all targets (including Tier 1 targets) is considered Tier 2.
+**Tier 3 targets** (not tested in CI, but theoretically there):
+
+- `x86_64-apple-darwin` (macOS on Intel)
+- Nix `aarch64-darwin`
+- Nix `x86_64-linux`
 
 Other platforms may be supported via cross-compilation or by building Zirco with a custom LLVM
-build, but this is not currently documented.
+toolchain, but this is not currently documented.
 
 Zirco does not support Windows, but the compiler runs normally on Windows via WSL. This guide also
 assumes your system has a C toolchain installed (for linking).


### PR DESCRIPTION
Must merge alongside https://github.com/zirco-lang/zircon/pull/21
Pending further discussion and a PR to `zircon`.

