### PR TITLE
Swap precedence order of boolean and bitwise operators.

### DIFF
--- a/book/src/reference.md
+++ b/book/src/reference.md
@@ -459,11 +459,11 @@ Operators are listed from highest to lowest precedence:
 | 3          | `as`                                         | Type cast                                                              | Left-to-right |
 | 4          | `*` `/` `%`                                  | Multiplication, division, modulo                                       | Left-to-right |
 | 5          | `+` `-`                                      | Addition, subtraction                                                  | Left-to-right |
-| 6          | `<` `<=` `>` `>=`                            | Comparison                                                             | Left-to-right |
-| 7          | `==` `!=`                                    | Equality                                                               | Left-to-right |
-| 8          | `&`                                          | Bitwise AND                                                            | Left-to-right |
-| 9          | `^`                                          | Bitwise XOR                                                            | Left-to-right |
-| 10         | `\|`                                         | Bitwise OR                                                             | Left-to-right |
+| 6          | `&`                                          | Bitwise AND                                                            | Left-to-right |
+| 7          | `^`                                          | Bitwise XOR                                                            | Left-to-right |
+| 8          | `\|`                                         | Bitwise OR                                                             | Left-to-right |
+| 9          | `<` `<=` `>` `>=`                            | Comparison                                                             | Left-to-right |
+| 10         | `==` `!=`                                    | Equality                                                               | Left-to-right |
 | 11         | `&&`                                         | Logical AND                                                            | Left-to-right |
 | 12         | `\|\|`                                       | Logical OR                                                             | Left-to-right |
 | 13         | `? :`                                        | Ternary conditional                                                    | Right-to-left |

--- a/compiler/zrc_parser/src/ast/expr.rs
+++ b/compiler/zrc_parser/src/ast/expr.rs
@@ -979,18 +979,14 @@ mod tests {
 			("a + b.c", "a + b.c"),
 			("a++ + b", "a++ + b"),
 			("a + b++", "a + b++"),
-			// Full integration
+			// Mostly-full integration, due to a rustc 1.100 nightly ICE
 			(
 				"a, b = c ? d : e || f && g == h > i | j ^ k & l + m * -n.o as P",
 				"a, b = c ? d : e || f && g == h > i | j ^ k & l + m * -n.o as P",
 			),
 			(
-				"a, (b = (c ? d : (e || (f && (g == (h > (i | (j ^ (k & (l + (m * ((-(n.o)) as P))))))))))))",
-				"a, b = c ? d : e || f && g == h > i | j ^ k & l + m * -n.o as P",
-			),
-			(
-				"((((((((((((a, b) = c) ? d : e) || f) && g) == h) > i) | j) ^ k) & l) + m) * (-n).o) as P",
-				"((((((((((((a, b) = c) ? d : e) || f) && g) == h) > i) | j) ^ k) & l) + m) * (-n).o) as P",
+				"((((((((((b = c) ? d : e) || f) && g) == h) > i) | j) ^ k) & l) + m) * (-n).o",
+				"((((((((((b = c) ? d : e) || f) && g) == h) > i) | j) ^ k) & l) + m) * (-n).o",
 			),
 		];
 

--- a/compiler/zrc_parser/src/ast/expr.rs
+++ b/compiler/zrc_parser/src/ast/expr.rs
@@ -151,16 +151,16 @@ enum Precedence {
 	LogicalOr = 4,
 	/// Logical AND
 	LogicalAnd = 5,
-	/// Bitwise OR
-	BitwiseOr = 6,
-	/// Bitwise XOR
-	BitwiseXor = 7,
-	/// Bitwise AND
-	BitwiseAnd = 8,
 	/// Equality operators
-	Equality = 9,
+	Equality = 6,
 	/// Comparison operators
-	Comparison = 10,
+	Comparison = 7,
+	/// Bitwise OR
+	BitwiseOr = 8,
+	/// Bitwise XOR
+	BitwiseXor = 9,
+	/// Bitwise AND
+	BitwiseAnd = 10,
 	/// Addition and subtraction
 	Term = 11,
 	/// Multiplication, division, modulo
@@ -345,10 +345,11 @@ impl std::fmt::Display for ExprKind<'_> {
 				Self::fmt_child(f, rhs, prec, true)
 			}
 			Self::Assignment(op, lhs, rhs) => {
+				// Reverse `is_right` for right-associative assignment
 				let prec = self.precedence();
-				Self::fmt_child(f, lhs, prec, false)?;
+				Self::fmt_child(f, lhs, prec, true)?;
 				write!(f, " {op} ")?;
-				Self::fmt_child(f, rhs, prec, true)
+				Self::fmt_child(f, rhs, prec, false)
 			}
 			Self::BinaryBitwise(op, lhs, rhs) => {
 				let prec = self.precedence();
@@ -889,6 +890,9 @@ mod tests {
 			"a >= b",
 			"a < b",
 			"a <= b",
+			"a | b",
+			"a ^ b",
+			"a & b",
 			"a + b",
 			"a - b",
 			"a * b",
@@ -936,6 +940,16 @@ mod tests {
 			("a + b * c", "a + b * c"),
 			("(a + b) * c", "(a + b) * c"),
 			("a * (b + c)", "a * (b + c)"),
+			// Bitwise AND binds tighter than XOR binds tighter than OR
+			("a & b ^ c | d", "a & b ^ c | d"),
+			("((a & b) ^ c) | d", "a & b ^ c | d"),
+			("a & (b ^ (c | d))", "a & (b ^ (c | d))"),
+			("a | b ^ c & d", "a | b ^ c & d"),
+			("a | (b ^ (c & d))", "a | b ^ c & d"),
+			("((a | b) ^ c) & d", "((a | b) ^ c) & d"),
+			// Bitwise OR binds tighter than Equality
+			("(a | b) == (c | d)", "a | b == c | d"),
+			("a | (b == c) | d", "a | (b == c) | d"),
 			// Comparison binds tighter than logical
 			("a < b && c > d", "a < b && c > d"),
 			("(a < b) && (c > d)", "a < b && c > d"), // Extra parens removed
@@ -950,6 +964,9 @@ mod tests {
 			// Multiple operators of same precedence (left associative)
 			("a - b - c", "a - b - c"),
 			("a - (b - c)", "a - (b - c)"),
+			// Multiple operators of same precedence (right associative)
+			("a = b = c", "a = b = c"),
+			("(a = b) = c", "(a = b) = c"),
 			// Unary operators
 			("!a && b", "!a && b"),
 			("!(a && b)", "!(a && b)"),
@@ -962,6 +979,19 @@ mod tests {
 			("a + b.c", "a + b.c"),
 			("a++ + b", "a++ + b"),
 			("a + b++", "a + b++"),
+			// Full integration
+			(
+				"a, b = c ? d : e || f && g == h > i | j ^ k & l + m * -n.o as P",
+				"a, b = c ? d : e || f && g == h > i | j ^ k & l + m * -n.o as P",
+			),
+			(
+				"a, (b = (c ? d : (e || (f && (g == (h > (i | (j ^ (k & (l + (m * ((-(n.o)) as P))))))))))))",
+				"a, b = c ? d : e || f && g == h > i | j ^ k & l + m * -n.o as P",
+			),
+			(
+				"((((((((((((a, b) = c) ? d : e) || f) && g) == h) > i) | j) ^ k) & l) + m) * (-n).o) as P",
+				"((((((((((((a, b) = c) ? d : e) || f) && g) == h) > i) | j) ^ k) & l) + m) * (-n).o) as P",
+			),
 		];
 
 		for (input, expected) in test_cases {

--- a/compiler/zrc_parser/src/internal_parser.lalrpop
+++ b/compiler/zrc_parser/src/internal_parser.lalrpop
@@ -333,7 +333,21 @@ LogicalOr = ExprPrecedenceTier<_LogicalOr, LogicalAnd>;
 _LogicalAnd: ExprKind<'input> = {
     <l:LogicalAnd> "&&" <r:Equality> => ExprKind::Logical(Logical::And, Box::new(l), Box::new(r)),
 };
-LogicalAnd = ExprPrecedenceTier<_LogicalAnd, Bitwise>;
+LogicalAnd = ExprPrecedenceTier<_LogicalAnd, Equality>;
+
+_Equality: ExprKind<'input> = {
+    <l:Equality> "==" <r:Comparison> => ExprKind::Equality(Equality::Eq, Box::new(l), Box::new(r)),
+    <l:Equality> "!=" <r:Comparison> => ExprKind::Equality(Equality::Neq, Box::new(l), Box::new(r)),
+};
+Equality: Expr<'input> = ExprPrecedenceTier<_Equality, Comparison>;
+
+_Comparison: ExprKind<'input> = {
+    <l:Comparison> ">" <r:Bitwise> => ExprKind::Comparison(Comparison::Gt, Box::new(l), Box::new(r)),
+    <l:Comparison> ">=" <r:Bitwise> => ExprKind::Comparison(Comparison::Gte, Box::new(l), Box::new(r)),
+    <l:Comparison> "<" <r:Bitwise> => ExprKind::Comparison(Comparison::Lt, Box::new(l), Box::new(r)),
+    <l:Comparison> "<=" <r:Bitwise> => ExprKind::Comparison(Comparison::Lte, Box::new(l), Box::new(r)),
+};
+Comparison: Expr<'input> = ExprPrecedenceTier<_Comparison, Bitwise>;
 
 Bitwise: Expr<'input> = BitwiseOr;
 _BitwiseOr: ExprKind<'input> = {
@@ -345,23 +359,9 @@ _BitwiseXor: ExprKind<'input> = {
 };
 BitwiseXor: Expr<'input> = ExprPrecedenceTier<_BitwiseXor, BitwiseAnd>;
 _BitwiseAnd: ExprKind<'input> = {
-    <l:BitwiseAnd> "&" <r:Equality> => ExprKind::BinaryBitwise(BinaryBitwise::And, Box::new(l), Box::new(r)),
+    <l:BitwiseAnd> "&" <r:Term> => ExprKind::BinaryBitwise(BinaryBitwise::And, Box::new(l), Box::new(r)),
 }
-BitwiseAnd: Expr<'input> = ExprPrecedenceTier<_BitwiseAnd, Equality>;
-
-_Equality: ExprKind<'input> = {
-    <l:Equality> "==" <r:Comparison> => ExprKind::Equality(Equality::Eq, Box::new(l), Box::new(r)),
-    <l:Equality> "!=" <r:Comparison> => ExprKind::Equality(Equality::Neq, Box::new(l), Box::new(r)),
-};
-Equality: Expr<'input> = ExprPrecedenceTier<_Equality, Comparison>;
-
-_Comparison: ExprKind<'input> = {
-    <l:Comparison> ">" <r:Term> => ExprKind::Comparison(Comparison::Gt, Box::new(l), Box::new(r)),
-    <l:Comparison> ">=" <r:Term> => ExprKind::Comparison(Comparison::Gte, Box::new(l), Box::new(r)),
-    <l:Comparison> "<" <r:Term> => ExprKind::Comparison(Comparison::Lt, Box::new(l), Box::new(r)),
-    <l:Comparison> "<=" <r:Term> => ExprKind::Comparison(Comparison::Lte, Box::new(l), Box::new(r)),
-};
-Comparison: Expr<'input> = ExprPrecedenceTier<_Comparison, Term>;
+BitwiseAnd: Expr<'input> = ExprPrecedenceTier<_BitwiseAnd, Term>;
 
 _Term: ExprKind<'input> = {
     <l:Term> "+" <r:Factor> => ExprKind::Arithmetic(Arithmetic::Addition, Box::new(l), Box::new(r)),

--- a/compiler/zrc_typeck/src/tast/expr.rs
+++ b/compiler/zrc_typeck/src/tast/expr.rs
@@ -143,16 +143,16 @@ enum Precedence {
 	LogicalOr = 4,
 	/// Logical AND
 	LogicalAnd = 5,
-	/// Bitwise OR
-	BitwiseOr = 6,
-	/// Bitwise XOR
-	BitwiseXor = 7,
-	/// Bitwise AND
-	BitwiseAnd = 8,
 	/// Equality operators
-	Equality = 9,
+	Equality = 6,
 	/// Comparison operators
-	Comparison = 10,
+	Comparison = 7,
+	/// Bitwise OR
+	BitwiseOr = 8,
+	/// Bitwise XOR
+	BitwiseXor = 9,
+	/// Bitwise AND
+	BitwiseAnd = 10,
 	/// Addition and subtraction
 	Term = 11,
 	/// Multiplication, division, modulo


### PR DESCRIPTION
# Changes
Moves BitwiseAnd, BitwiseOr, and BitwiseXor between Comparison and Term.

## Minor bugs fixed
- Bitwise operators were not present in unit tests.
- Bitwise AND was given incorrect RHS in LALRPop grammar, effectively becoming right-associative (maybe?)
- Assignment operators were formatted as if left-associative, which may have lead to unwanted parentheses.

Due to the aforementioned `&` associativity issue, this shouldn't be a breaking change, as previous code couldn't rely on operator precedence (maybe?)