### PR TITLE
lang: add intrinsic functions

### DIFF
--- a/book/src/reference.md
+++ b/book/src/reference.md
@@ -106,12 +106,14 @@ type     switch   default  new      unreachable
 
 The `IDENTIFIER` terminal is used to represent user-provided identifiers.
 
-Form: `[a-zA-Z_][a-zA-Z0-9_]*`
+Form: `@?[a-zA-Z_][a-zA-Z0-9_]*`
+
+Identifiers beginning with `@` are reserved for standardized intrinsics.
 
 Implementations MAY reserve the following identifiers for their own use:
 
-- Identifiers beginning with `__` (two underscores)
-- Identifiers beginning with `_` (one underscore) followed by an uppercase letter (e.g. `_Z`)
+- Identifiers beginning with `__` or `@__` (two underscores)
+- Identifiers beginning with `_` or `@_` (one underscore) followed by an uppercase letter (e.g. `_Z`)
 
 #### 3.5.2. `NUMBER_LITERAL`
 
@@ -558,6 +560,11 @@ A function or function pointer `f` can be called with `f(a, b, c)`, where `a`, `
 arguments to the function. The number and types of the arguments must match. If the function has
 a variadic `...` trailing in its type, an infinite number of arbitrary arguments may be passed.
 
+#### 5.3.4.1. Intrinsic Function Calls
+
+[Intrinsic functions](#8-compiler-intrinsics) may be called using `@name(args)`. Intrinsic identifiers
+(`@name`) must be rejected in any other position.
+
 #### 5.3.5. Postfix Increment/Decrement
 
 The postfix increment `x++` and decrement `x--` operators increment or decrement the value of
@@ -834,9 +841,28 @@ fn foo(a: i32, b: i32) -> i32 {
 If the body is elided, it is assumed to be an extern declaration, using the C calling convention.
 If the body is elided, you may also include `...` to indicate that the function is variadic.
 
-## 8. Program Structure
+## 8. Compiler Intrinsics
 
-### 8.1. Entry Point
+Compiler intrinsics are used to provide special functionality the language does not directly provide.
+
+### 8.1. `@volatile_read`
+
+For any `T`, the intrinsic `@volatile_read(ptr: *T) -> T` provides a method of generating reads that
+the compiler MUST NOT optimize away. This is useful for MMIO, primarily.
+
+### 8.2. `@volatile_write`
+
+For any `T`, the intrinsic `@volatile_write(ptr: *T, val: T)` provides a method of generating memory
+writes that the compiler MUST NOT optimize away.
+
+### 8.3. `@shl` and `@shr`
+
+For any integer type (signed or unsigned) `N`, `@shl(val: N, bits: usize)` executes a binary leftwards
+shift by `bits` bits. `@shr` has an identical signature, instead performing a right shift.
+
+## 9. Program Structure
+
+### 9.1. Entry Point
 
 All Zirco programs follow the `crt0.S` entry point of either of the following signatures:
 
@@ -845,13 +871,13 @@ fn main() -> i32;
 fn main(argc: i32, argv: **u8) -> i32;
 ```
 
-### 8.2. Compilation Units
+### 9.2. Compilation Units
 
 The Zirco compiler compiles a single source file at a time, and each source file is a compilation
 unit. Each compilation unit has its own global scope, and the contents of one compilation unit are
 not visible to another compilation unit unless they are explicitly imported via `#include`.
 
-## 9. Standard Library
+## 10. Standard Library
 
 Zirco's standard library, `libzr`, is currently under development. The correct API surface is as is
 defined by the `libzr` project in the zrc monorepo.

--- a/compiler/zrc_codegen/src/expr.rs
+++ b/compiler/zrc_codegen/src/expr.rs
@@ -112,6 +112,9 @@ pub(crate) fn cg_expr<'ctx, 'input, 'a>(
 		TypedExprKind::Dot(place, key) => mem::cg_dot(ce, place, key),
 
 		TypedExprKind::Call(f, args) => control::cg_call(ce, *f, args),
+		TypedExprKind::IntrinsicCall(intrinsic, args) => {
+			control::cg_intrinsic_call(ce, intrinsic, args)
+		}
 
 		TypedExprKind::PostfixIncrement(place) => {
 			increment_decrement::cg_postfix_increment(ce, *place)

--- a/compiler/zrc_codegen/src/expr/control.rs
+++ b/compiler/zrc_codegen/src/expr/control.rs
@@ -1,6 +1,6 @@
 //! code generation for control flow expressions
 
-use inkwell::values::{BasicValue, BasicValueEnum};
+use inkwell::values::{BasicMetadataValueEnum, BasicValue, BasicValueEnum};
 use zrc_typeck::tast::expr::{Place, TypedExpr};
 
 use super::place::cg_place;
@@ -51,6 +51,93 @@ pub fn cg_call<'ctx, 'input>(
 	} else {
 		cg.ctx.i8_type().get_undef().as_basic_value_enum()
 	})
+}
+
+/// Code generate an intrinsic call
+pub fn cg_intrinsic_call<'ctx, 'input>(
+	CgExprArgs { cg, bb, .. }: CgExprArgs<'ctx, 'input, '_>,
+	intrinsic: &'input str,
+	args: Vec<TypedExpr<'input>>,
+) -> BasicBlockAnd<'ctx, BasicValueEnum<'ctx>> {
+	let mut bb = bb;
+	let old_args = args;
+	let mut args: Vec<BasicMetadataValueEnum> = vec![];
+	for arg in old_args.clone() {
+		let new_arg = unpack!(bb = cg_expr(cg, bb, arg));
+		args.push(new_arg.into());
+	}
+
+	match intrinsic {
+		"shl" | "shr" => {
+			// LLVM wants both operands to be of the same type, but Zirco uses
+			// `usize` for the RHS operand so we need to cast it to the same
+			// type as the LHS operand
+			let lhs_type = args[0].into_int_value().get_type();
+			let rhs_type = args[1].into_int_value().get_type();
+
+			// we trunc if usize > lhs_type, otherwise we extend
+			let rhs = if rhs_type.get_bit_width() > lhs_type.get_bit_width() {
+				cg.builder
+					.build_int_truncate(args[1].into_int_value(), lhs_type, "cast_rhs_to_lhs")
+					.expect("cast should have been created successfully")
+			} else {
+				cg.builder
+					.build_int_s_extend(args[1].into_int_value(), lhs_type, "cast_rhs_to_lhs")
+					.expect("cast should have been created successfully")
+			};
+
+			let ret = match intrinsic {
+				"shl" => cg
+					.builder
+					.build_left_shift(args[0].into_int_value(), rhs, "shl")
+					.expect("shl should have been created successfully"),
+				"shr" => cg
+					.builder
+					.build_right_shift(args[0].into_int_value(), rhs, false, "shr")
+					.expect("shr should have been created successfully"),
+				_ => unreachable!(),
+			};
+
+			bb.and(ret.as_basic_value_enum())
+		}
+		"volatile_write" => {
+			// args[0] is a pointer, args[1] is the value to write
+			cg.builder
+				.build_store(args[0].into_pointer_value(), args[1].into_int_value())
+				.expect("store should have been created successfully")
+				.set_volatile(true)
+				.expect("store should have been created successfully");
+
+			bb.and(
+				cg.ctx
+					.struct_type(&[], false)
+					.get_undef()
+					.as_basic_value_enum(),
+			)
+		}
+		"volatile_read" => {
+			// args[0] is a pointer
+			let ret = cg
+				.builder
+				.build_load(
+					llvm_basic_type(&cg, &old_args[0].inferred_type).0,
+					args[0].into_pointer_value(),
+					"volatile_read",
+				)
+				.expect("load should have been created successfully");
+			ret.as_instruction_value()
+				.expect("load should be an instruction")
+				.set_volatile(true)
+				.expect("load should have been created successfully");
+
+			bb.and(ret.as_basic_value_enum())
+		}
+
+		_ => unreachable!(
+			"intrinsic {} should have been rejected in typeck",
+			intrinsic
+		),
+	}
 }
 
 /// Code generate a ternary expression
@@ -159,5 +246,22 @@ mod tests {
                     take_int(num);
                 }
             "});
+	}
+
+	#[test]
+	fn intrinsics_generate() {
+		cg_snapshot_test!(indoc! {"
+			fn test() {
+				let nullptr = 0 as *i32;
+
+				// TEST: volatile read/write must generate
+				@volatile_write(nullptr, 42i32);
+				let x: i32 = @volatile_read(nullptr);
+
+				// TEST: shl/shr must generate
+				let y = @shl(x, 2usize);
+				let z = @shr(y, 1usize);
+			}
+		"});
 	}
 }

--- a/compiler/zrc_codegen/src/expr/snapshots/zrc_codegen__expr__control__tests__intrinsics_generate.snap
+++ b/compiler/zrc_codegen/src/expr/snapshots/zrc_codegen__expr__control__tests__intrinsics_generate.snap
@@ -1,0 +1,54 @@
+---
+source: compiler/zrc_codegen/src/expr/control.rs
+description: "fn test() {\n\tlet nullptr = 0 as *i32;\n\n\t// TEST: volatile read/write must generate\n\t@volatile_write(nullptr, 42i32);\n\tlet x: i32 = @volatile_read(nullptr);\n\n\t// TEST: shl/shr must generate\n\tlet y = @shl(x, 2usize);\n\tlet z = @shr(y, 1usize);\n}\n"
+expression: resulting_ir
+---
+; ModuleID = 'test.zr'
+source_filename = "test.zr"
+
+define {} @test() !dbg !3 {
+entry:
+  %let_z = alloca i32, align 4
+  %let_y = alloca i32, align 4
+  %let_x = alloca i32, align 4
+  %let_nullptr = alloca ptr, align 8
+  store ptr null, ptr %let_nullptr, align 8, !dbg !8
+  %load = load ptr, ptr %let_nullptr, align 8, !dbg !11
+  store volatile i32 42, ptr %load, align 4, !dbg !12
+  %load1 = load ptr, ptr %let_nullptr, align 8, !dbg !13
+  %volatile_read = load volatile ptr, ptr %load1, align 8, !dbg !13
+  store ptr %volatile_read, ptr %let_x, align 8, !dbg !14
+  %load2 = load i32, ptr %let_x, align 4, !dbg !15
+  %shl = shl i32 %load2, 2, !dbg !16
+  store i32 %shl, ptr %let_y, align 4, !dbg !17
+  %load3 = load i32, ptr %let_y, align 4, !dbg !18
+  %shr = lshr i32 %load3, 1, !dbg !19
+  store i32 %shr, ptr %let_z, align 4, !dbg !20
+  ret {} zeroinitializer, !dbg !21
+}
+
+!llvm.module.flags = !{!0}
+!llvm.dbg.cu = !{!1}
+
+!0 = !{i32 2, !"Debug Info Version", i32 3}
+!1 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "zrc test runner", isOptimized: false, flags: "zrc --fake-args", runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false)
+!2 = !DIFile(filename: "test.zr", directory: "/fake/path")
+!3 = distinct !DISubprogram(name: "test", linkageName: "test", scope: null, file: !2, line: 1, type: !4, scopeLine: 1, spFlags: DISPFlagDefinition, unit: !1)
+!4 = !DISubroutineType(types: !5)
+!5 = !{!6}
+!6 = !DICompositeType(tag: DW_TAG_structure_type, name: "struct {}", scope: !2, file: !2, elements: !7)
+!7 = !{}
+!8 = !DILocation(line: 2, column: 6, scope: !9)
+!9 = distinct !DILexicalBlock(scope: !10, file: !2, line: 1, column: 11)
+!10 = distinct !DILexicalBlock(scope: !3, file: !2, line: 1, column: 11)
+!11 = !DILocation(line: 5, column: 18, scope: !9)
+!12 = !DILocation(line: 5, column: 27, scope: !9)
+!13 = !DILocation(line: 6, column: 30, scope: !9)
+!14 = !DILocation(line: 6, column: 6, scope: !9)
+!15 = !DILocation(line: 9, column: 15, scope: !9)
+!16 = !DILocation(line: 9, column: 18, scope: !9)
+!17 = !DILocation(line: 9, column: 6, scope: !9)
+!18 = !DILocation(line: 10, column: 15, scope: !9)
+!19 = !DILocation(line: 10, column: 18, scope: !9)
+!20 = !DILocation(line: 10, column: 6, scope: !9)
+!21 = !DILocation(line: 11, column: 1, scope: !9)

--- a/compiler/zrc_diagnostics/src/diagnostic.rs
+++ b/compiler/zrc_diagnostics/src/diagnostic.rs
@@ -214,7 +214,7 @@ where
 		// read the source from the path inside of the span. if it is <stdin>,
 		// use the provided piped source.
 		let (source, path) = match span.file_name() {
-			"/dev/<stdin>" => (
+			"/dev/<stdin>" | "-" => (
 				piped_source
 					.expect("piped source must be provided for <stdin>")
 					.to_string(),

--- a/compiler/zrc_diagnostics/src/diagnostic_kind.rs
+++ b/compiler/zrc_diagnostics/src/diagnostic_kind.rs
@@ -136,6 +136,10 @@ pub enum DiagnosticKind {
 	InvalidNumberLiteral(String),
 	#[error("multiple default cases found")]
 	MultipleDefaultCases,
+	#[error("cannot use an intrinsic here")]
+	CannotUseIntrinsicHere,
+	#[error("unknown intrinsic `@{0}`")]
+	UnknownIntrinsic(String),
 
 	// PREPROCESSOR ERRORS
 	#[error("unterminated include directive")]
@@ -232,6 +236,8 @@ impl ErrorCode for DiagnosticKind {
 			Self::FunctionNotFirstClass => "E3043",
 			Self::InvalidNumberLiteral(_) => "E3044",
 			Self::MultipleDefaultCases => "E3045",
+			Self::CannotUseIntrinsicHere => "E3046",
+			Self::UnknownIntrinsic(_) => "E3047",
 		}
 	}
 }
@@ -372,6 +378,10 @@ pub enum LabelKind {
 	MultipleDefaultCases,
 	#[error("invalid shebang")]
 	PreprocessorInvalidShebang,
+	#[error("cannot use an intrinsic here")]
+	CannotUseIntrinsicHere,
+	#[error("unknown intrinsic `@{0}`")]
+	UnknownIntrinsic(String),
 }
 
 /// The list of possible notes attached to a [`Diagnostic`]
@@ -412,6 +422,8 @@ pub enum NoteKind {
 	PointerArithmeticRequiresUsize,
 	#[error("a shebang must end in a linefeed")]
 	ShebangMustEndWithNewline,
+	#[error("identifiers beginning with `@` are reserved for zrc intrinsics")]
+	ReservedIntrinsicIdentifiers,
 }
 
 /// The list of possible help messages attached to a [`Diagnostic`]

--- a/compiler/zrc_parser/src/lexer.rs
+++ b/compiler/zrc_parser/src/lexer.rs
@@ -594,7 +594,7 @@ pub enum Tok<'input> {
 	#[display("{_0}")]
 	NumberLiteral(NumberLiteral<'input>),
 	/// Any identifier
-	#[regex(r"[a-zA-Z_][a-zA-Z0-9_]*", lexer_slice)]
+	#[regex(r"@?[a-zA-Z_][a-zA-Z0-9_]*", lexer_slice)]
 	#[display("{_0}")]
 	Identifier(&'input str),
 }

--- a/compiler/zrc_typeck/src/tast/expr.rs
+++ b/compiler/zrc_typeck/src/tast/expr.rs
@@ -95,6 +95,8 @@ pub enum TypedExprKind<'input> {
 	Dot(Box<Place<'input>>, Spanned<&'input str>),
 	/// `a(b, c, d, ...)`
 	Call(Box<Place<'input>>, Vec<TypedExpr<'input>>),
+	/// `@name(a, b, c, ...)` - intrinsic call
+	IntrinsicCall(&'input str, Vec<TypedExpr<'input>>),
 	/// `x++` - postfix increment (returns old value then increments)
 	PostfixIncrement(Box<Place<'input>>),
 	/// `x--` - postfix decrement (returns old value then decrements)
@@ -201,6 +203,7 @@ impl TypedExprKind<'_> {
 			Self::Index(_, _)
 			| Self::Dot(_, _)
 			| Self::Call(_, _)
+			| Self::IntrinsicCall(_, _)
 			| Self::PostfixIncrement(_)
 			| Self::PostfixDecrement(_) => Precedence::Postfix,
 			Self::NumberLiteral(_, _)
@@ -334,6 +337,14 @@ impl Display for TypedExprKind<'_> {
 			Self::Call(place, args) => write!(
 				f,
 				"{place}({})",
+				args.iter()
+					.map(ToString::to_string)
+					.collect::<Vec<String>>()
+					.join(", ")
+			),
+			Self::IntrinsicCall(name, args) => write!(
+				f,
+				"@{name}({})",
 				args.iter()
 					.map(ToString::to_string)
 					.collect::<Vec<String>>()

--- a/compiler/zrc_typeck/src/typeck.rs
+++ b/compiler/zrc_typeck/src/typeck.rs
@@ -3,6 +3,7 @@
 mod block;
 mod declaration;
 mod expr;
+mod intrinsic;
 mod scope;
 mod ty;
 

--- a/compiler/zrc_typeck/src/typeck/expr/call.rs
+++ b/compiler/zrc_typeck/src/typeck/expr/call.rs
@@ -1,7 +1,7 @@
 //! type checking for call expressions
 
 use zrc_diagnostics::{Diagnostic, DiagnosticKind, LabelKind, SpanExt, diagnostic::GenericLabel};
-use zrc_parser::ast::expr::Expr;
+use zrc_parser::ast::expr::{Expr, ExprKind};
 use zrc_utils::span::{Span, Spannable, Spanned};
 
 use super::{
@@ -9,10 +9,13 @@ use super::{
 	helpers::{expr_to_place, try_coerce_to},
 	type_expr,
 };
-use crate::tast::{
-	expr::{TypedExpr, TypedExprKind},
-	stmt::ArgumentDeclarationList,
-	ty::{Fn, Type as TastType},
+use crate::{
+	tast::{
+		expr::{TypedExpr, TypedExprKind},
+		stmt::ArgumentDeclarationList,
+		ty::{Fn, Type as TastType},
+	},
+	typeck::intrinsic::Intrinsic,
 };
 
 /// Typeck a call expr
@@ -24,6 +27,34 @@ pub fn type_expr_call<'input>(
 	args: Spanned<Vec<Expr<'input>>>,
 ) -> Result<TypedExpr<'input>, Diagnostic> {
 	let f_span = f.0.span();
+
+	if let ExprKind::Identifier(id) = &f.0.value()
+		&& let Some(intrinsic_name) = id.strip_prefix('@')
+	{
+		// I FUCKING LOVE LET CHAINS ARGHHHHH
+
+		let Some(intrinsic) = Intrinsic::from_name(intrinsic_name) else {
+			return Err(DiagnosticKind::UnknownIntrinsic(intrinsic_name.to_string())
+				.error_in(f_span)
+				.with_label(GenericLabel::error(
+					LabelKind::UnknownIntrinsic(intrinsic_name.to_string()).in_span(f_span),
+				)));
+		};
+
+		let args_t = args
+			.value()
+			.iter()
+			.map(|x| type_expr(scope, x.clone()))
+			.collect::<Result<Vec<TypedExpr>, Diagnostic>>()?;
+
+		let inferred_type = intrinsic.check(&args_t, expr_span)?;
+
+		return Ok(TypedExpr {
+			inferred_type,
+			kind: TypedExprKind::IntrinsicCall(intrinsic_name, args_t).in_span(expr_span),
+		});
+	}
+
 	let ft = type_expr(scope, f)?;
 	let args_span = args.span();
 	let args_t = args

--- a/compiler/zrc_typeck/src/typeck/expr/literals.rs
+++ b/compiler/zrc_typeck/src/typeck/expr/literals.rs
@@ -141,6 +141,15 @@ pub fn type_expr_identifier<'input>(
 	expr_span: Span,
 	i: &'input str,
 ) -> Result<TypedExpr<'input>, Diagnostic> {
+	if i.starts_with('@') {
+		return Err(DiagnosticKind::CannotUseIntrinsicHere
+			.error_in(expr_span)
+			.with_label(GenericLabel::error(
+				LabelKind::CannotUseIntrinsicHere.in_span(expr_span),
+			))
+			.with_note(NoteKind::ReservedIntrinsicIdentifiers));
+	}
+
 	let ty_rc = scope.values.resolve_mut(i).ok_or_else(|| {
 		let base = DiagnosticKind::UnableToResolveIdentifier(i.to_string())
 			.error_in(expr_span)

--- a/compiler/zrc_typeck/src/typeck/intrinsic.rs
+++ b/compiler/zrc_typeck/src/typeck/intrinsic.rs
@@ -1,0 +1,155 @@
+//! Type checking rules zrc intrinsics, function calls prefixed with `@`.
+
+use zrc_diagnostics::{Diagnostic, DiagnosticKind, LabelKind, diagnostic::GenericLabel};
+use zrc_utils::{
+	ordered_fields::OrderedFields,
+	span::{Span, Spannable},
+};
+
+use crate::tast::{expr::TypedExpr, ty::Type as TastType};
+
+/// Available zrc intrinsics
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Intrinsic {
+	/// for `T: {int}`, `@shl(T, usize) -> T`
+	Shl,
+	/// for `T: {int}`, `@shr(T, usize) -> T`
+	Shr,
+	/// forall T, `@volatile_write(*T, T) -> void`
+	VolatileWrite,
+	/// forall T, `@volatile_read(*T) -> T`
+	VolatileRead,
+}
+
+impl Intrinsic {
+	/// Get an intrinsic from its name, if it exists.
+	pub fn from_name(name: &str) -> Option<Self> {
+		match name {
+			"shl" => Some(Self::Shl),
+			"shr" => Some(Self::Shr),
+			"volatile_write" => Some(Self::VolatileWrite),
+			"volatile_read" => Some(Self::VolatileRead),
+			_ => None,
+		}
+	}
+
+	/// Type check an intrinsic call.
+	///
+	/// Intrinsics have special type rules that functions can't use yet, so they
+	/// get dedicated type checking machinery.
+	pub fn check<'input>(
+		self,
+		args: &[TypedExpr<'input>],
+		span: Span,
+	) -> Result<TastType<'input>, Diagnostic> {
+		match self {
+			Self::Shl | Self::Shr => {
+				// for any integer type T,
+				// @shl/@shr(T, usize) -> T
+
+				if args.len() != 2 {
+					return Err(DiagnosticKind::FunctionArgumentCountMismatch {
+						expected: "2".to_string(),
+						got: args.len().to_string(),
+					}
+					.error_in(span)
+					.with_label(GenericLabel::error(
+						LabelKind::FunctionArgumentCountMismatch {
+							expected: "2".to_string(),
+							got: args.len().to_string(),
+						}
+						.in_span(span),
+					)));
+				}
+
+				if !args[0].inferred_type.is_integer() {
+					return Err(DiagnosticKind::FunctionArgumentTypeMismatch {
+						n: 0,
+						expected: "{int}".to_string(),
+						got: args[0].inferred_type.to_string(),
+					}
+					.error_in(span));
+				}
+
+				if args[1].inferred_type != TastType::Usize {
+					return Err(DiagnosticKind::FunctionArgumentTypeMismatch {
+						n: 1,
+						expected: "usize".to_string(),
+						got: args[1].inferred_type.to_string(),
+					}
+					.error_in(span));
+				}
+
+				Ok(args[0].inferred_type.clone())
+			}
+			Self::VolatileRead => {
+				// @volatile_read(*T) -> T
+				if args.len() != 1 {
+					return Err(DiagnosticKind::FunctionArgumentCountMismatch {
+						expected: "1".to_string(),
+						got: args.len().to_string(),
+					}
+					.error_in(span)
+					.with_label(GenericLabel::error(
+						LabelKind::FunctionArgumentCountMismatch {
+							expected: "1".to_string(),
+							got: args.len().to_string(),
+						}
+						.in_span(span),
+					)));
+				}
+
+				if let TastType::Ptr(inner) = &args[0].inferred_type {
+					Ok(*inner.clone())
+				} else {
+					Err(DiagnosticKind::FunctionArgumentTypeMismatch {
+						n: 0,
+						expected: "*T".to_string(),
+						got: args[0].inferred_type.to_string(),
+					}
+					.error_in(span))
+				}
+			}
+			Self::VolatileWrite => {
+				// @volatile_write(*T, T) -> void
+				if args.len() != 2 {
+					return Err(DiagnosticKind::FunctionArgumentCountMismatch {
+						expected: "2".to_string(),
+						got: args.len().to_string(),
+					}
+					.error_in(span)
+					.with_label(GenericLabel::error(
+						LabelKind::FunctionArgumentCountMismatch {
+							expected: "2".to_string(),
+							got: args.len().to_string(),
+						}
+						.in_span(span),
+					)));
+				}
+
+				if let TastType::Ptr(inner) = &args[0].inferred_type {
+					if **inner != args[1].inferred_type {
+						return Err(DiagnosticKind::FunctionArgumentTypeMismatch {
+							n: 1,
+							expected: inner.to_string(),
+							got: args[1].inferred_type.to_string(),
+						}
+						.error_in(span));
+					}
+				} else {
+					return Err(DiagnosticKind::FunctionArgumentTypeMismatch {
+						n: 0,
+						expected: "*T".to_string(),
+						got: args[0].inferred_type.to_string(),
+					}
+					.error_in(span));
+				}
+
+				Ok(TastType::Struct {
+					fields: OrderedFields::new(),
+					packed: false,
+				})
+			}
+		}
+	}
+}

--- a/compiler/zrc_visitor/src/tast.rs
+++ b/compiler/zrc_visitor/src/tast.rs
@@ -67,6 +67,11 @@ pub trait SemanticVisit<'input, 'gs> {
 					self.visit_tc_expr(arg);
 				}
 			}
+			TcExprKind::IntrinsicCall(_, args) => {
+				for arg in args {
+					self.visit_tc_expr(arg);
+				}
+			}
 			TcExprKind::Ternary(cond, if_true, if_false) => {
 				self.visit_tc_expr(cond.as_ref());
 				self.visit_tc_expr(if_true.as_ref());

--- a/tools/zircop/src/lints/unused_statement.rs
+++ b/tools/zircop/src/lints/unused_statement.rs
@@ -81,6 +81,7 @@ fn has_side_effects(expr: &TypedExprKind<'_>) -> bool {
 		// Expressions with direct side effects
 		TypedExprKind::Assignment(_, _)
 		| TypedExprKind::Call(_, _)
+		| TypedExprKind::IntrinsicCall(_, _)
 		| TypedExprKind::PrefixIncrement(_)
 		| TypedExprKind::PrefixDecrement(_)
 		| TypedExprKind::PostfixIncrement(_)


### PR DESCRIPTION
fixes #781 

Adds a mechanism for _intrinsics_, like `let val = @volatile_read(ptr);`.

It was originally considered to also convert `unreachable` to an intrinsic, but currently `cg_expr` contains no mechanism to cease code generation for the block.